### PR TITLE
Always display info prompt and constrain text columns in target tab to visual region.

### DIFF
--- a/src/storyq.css
+++ b/src/storyq.css
@@ -144,7 +144,7 @@ p {
 .sq-target-lower-panel {
     margin: 5px;
     width: 100%;
-    height: 100vh;
+    height: calc(100vh - 140px);
     flex: 1 1 auto;
     display: flex;
     flex-direction: row;

--- a/src/storyq.css
+++ b/src/storyq.css
@@ -49,7 +49,19 @@ table {
 }
 
 #tabPanel {
-    flex: 1 1 auto;
+    flex: 1 1 content;
+    overflow: hidden;
+/*     display: flex; */
+/*     flex-direction: column; */
+}
+
+.dx-tabpanel-tabs {
+	flex: 0 0 content;
+}
+
+.dx-tab-panel-container {
+	flex-grow: 1;
+	flex-shrink: 1;
 }
 
 .title {
@@ -235,7 +247,7 @@ p {
     color: #187992;
     font-style: italic;
     background-color: white;
-    flex: 0 0 auto;
+    flex: 0 0 content;
 }
 
 .sq-progress-bar-container {


### PR DESCRIPTION
I was unable to get finish with the scrolling behavior on other tabs. The "target" tab should work correctly, though, and the bottom message is correct.