### PR TITLE
fix: CODAP case creation notification listener not setup when plugin starts as collapsed [PT-185324855]

### DIFF
--- a/src/components/testing_panel.tsx
+++ b/src/components/testing_panel.tsx
@@ -13,24 +13,24 @@ import {action, toJS} from "mobx";
 import {TestingManager} from "../managers/testing_manager";
 import {SQ} from "../lists/lists";
 
+export const kNonePresent = 'None present';
+
 export interface Testing_Props {
 	uiStore: UiStore
 	domainStore: DomainStore
+	testingManager: TestingManager
 }
 
 export const TestingPanel = observer(class TestingPanel extends Component<Testing_Props> {
 
 	testingManager: TestingManager
-	kNonePresent = 'None present'
 
-	constructor(props: any) {
+	constructor(props: Testing_Props) {
 		super(props);
 		this.handleDataContextNotification = this.handleDataContextNotification.bind(this)
-		this.handleCaseNotification = this.handleCaseNotification.bind(this)
 		codapInterface.on('notify', '*', '', this.handleDataContextNotification);
-		codapInterface.on('notify', '*', 'createCases', this.handleCaseNotification);
 
-		this.testingManager = new TestingManager(this.props.domainStore, this.kNonePresent)
+		this.testingManager = props.testingManager;
 	}
 
 	async handleDataContextNotification(iNotification: CODAP_Notification) {
@@ -44,12 +44,6 @@ export const TestingPanel = observer(class TestingPanel extends Component<Testin
 				await this.updateCodapInfo()
 			}
 		}
-	}
-
-	async handleCaseNotification(iNotification: CODAP_Notification) {
-		const tDataContextName = iNotification.resource && iNotification.resource.match(/\[(.+)]/)[1]
-		if (tDataContextName === this.props.domainStore.testingStore.testingDatasetInfo.name)
-			await this.testingManager.classify(false)
 	}
 
 	async updateCodapInfo() {
@@ -129,7 +123,7 @@ export const TestingPanel = observer(class TestingPanel extends Component<Testin
 		function getClassAttributeChoice() {
 			if (tTestingStore.testingDatasetInfo.title !== '') {
 				const tAttributeNames: string[] = toJS(tTestingStore.testingAttributeNames)
-				tAttributeNames.unshift(this_.kNonePresent)
+				tAttributeNames.unshift(kNonePresent)
 				return choicesMenu('Choose the column with the labels (optional)', 'Choose a column',
 					SQ.hints.testingLabelsChoices,
 					tAttributeNames,


### PR DESCRIPTION
This fixes an issue with the case creation notification not running when this plugin is included in a CODAP document and the plugin is collapsed (minimized) at load time.  This manifested as predictions not being updated when new cases were created in the testing table in the "Exploring AI in ELA with StoryQ (SY 2022)" sequence as the plugin was collapsed on page 4 in the first activity.

The tab component in the root Storyq component was not rendering the TestingPanel when the plugin was collapsed and the TestingPanel setup the CODAP case creation listener.

This fix pulls the testing manager instance creation and case creation listener into the root component and passes them down to the TestingPanel.  This allows the case creation notification to be handled when the plugin is collapsed.