### PR TITLE
188150453 StoryQ in v3

### DIFF
--- a/src/components/feature_pane.tsx
+++ b/src/components/feature_pane.tsx
@@ -71,7 +71,7 @@ export const FeaturePane = observer(class FeaturePane extends Component<Feature_
 							else {
 								tFeatureUnderConstruction.name = this.props.domainStore.featureStore.constructNameFor(tFeatureUnderConstruction)
 								await this.props.domainStore.targetStore.addOrUpdateFeatureToTarget(tFeatureUnderConstruction)
-								await this.props.domainStore.featureStore.addFeatureUnderConstruction()
+								await this.props.domainStore.featureStore.addFeatureUnderConstruction(tFeatureUnderConstruction)
 								await this.props.domainStore.updateNonNtigramFeaturesDataset()
 								await this.props.domainStore.updateNgramFeatures()
 								tFeatureUnderConstruction.inProgress = false

--- a/src/components/storyq.tsx
+++ b/src/components/storyq.tsx
@@ -32,7 +32,7 @@ const Storyq = observer(class Storyq extends Component<{}, {}> {
 		private domainStore: DomainStore
 		private notificationManager: NotificationManager
 		private kPluginName = kStoryQPluginName;
-		private kVersion = "2.15";
+		private kVersion = "2.16";
 		private kInitialDimensions = {
 			width: 429,
 			height: 420

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -214,11 +214,13 @@ export async function getAttributeNames(iDatasetName: string, iCollectionName: s
  * @param iDatasetName
  * @param iCollectionName
  */
-export async function getCaseValues(iDatasetName: string,
-																		iCollectionName: string): Promise<Case[]> {
+export async function getCaseValues(
+	iDatasetName: string, iCollectionName: string, searchFormula?: string
+): Promise<Case[]> {
+	const formula = searchFormula ?? `true`;
 	const tResult: any = await codapInterface.sendRequest({
 		action: 'get',
-		resource: `dataContext[${iDatasetName}].collection[${iCollectionName}].caseFormulaSearch[true]`
+		resource: `dataContext[${iDatasetName}].collection[${iCollectionName}].caseFormulaSearch[${formula}]`
 	}).catch(reason => console.log(`Unable to get cases in ${iDatasetName} because ${reason}`))
 	if (tResult.success) {
 		return tResult.values.map((iValue: any) => {

--- a/src/managers/headings_manager.ts
+++ b/src/managers/headings_manager.ts
@@ -47,6 +47,7 @@ export class HeadingsManager {
 					bold: true
 				})
 			}
+			if (children.length === 0) children.push({ text: "" })
 			return {
 				type: "paragraph",
 				children

--- a/src/managers/headings_manager.ts
+++ b/src/managers/headings_manager.ts
@@ -19,40 +19,38 @@ export class HeadingsManager {
 	public setupHeadings(iNegLabel:string, iPosLabel:string, iBlankLabel:string,
 											 iActual:string | null, iPredicted:string | null) {
 		function fillInHeading( iFirst:string | null, iSecond:string | null, iColor:string) {
-			let tFirstPhrase = !iFirst ? '{},{},' : `
-				{
-					"text": "${iActual} = ",
-					"color": "${iColor}",
-					"italic": true
-				},
-				{
-					"text": "${iFirst}",
-					"color": "${iColor}",
-					"italic": true,
-					"bold": true
-				}, 
-				{
-					"text": ", "
-				}, 
-			`;
-			let	tSecondPhrase = !Boolean(iSecond) ? '{},{}' : `
-					{
-						"text": "${iPredicted} = ",
-						"color": "${iColor}",
-						"italic": true
-					},
-					{
-						"text": "${iSecond}",
-						"color": "${iColor}",
-						"italic": true,
-						"bold": true
-					}
-				`;
-			let	tHeading = `{
-        "type": "paragraph",
-        "children": [${tFirstPhrase}${tSecondPhrase}]
-      }`;
-			return JSON.parse( tHeading);
+			const children = []
+			if (iFirst) {
+				children.push({
+					text: `${iActual} =`,
+					color: iColor,
+					italic: true
+				})
+				children.push({
+					text: iFirst,
+					color: iColor,
+					italic: true,
+					bold: true
+				})
+				children.push({ text: ", " })
+			}
+			if (iSecond) {
+				children.push({
+					text: `${iPredicted} = `,
+					color: iColor,
+					italic: true
+				})
+				children.push({
+					text: iSecond,
+					color: iColor,
+					italic: true,
+					bold: true
+				})
+			}
+			return {
+				type: "paragraph",
+				children
+			}
 		}
 		this.classLabels = {
 			negLabel: iNegLabel,

--- a/src/managers/text_feedback_manager.ts
+++ b/src/managers/text_feedback_manager.ts
@@ -246,7 +246,10 @@ export default class TextFeedbackManager {
 				// Get the features and stash them in a set
 				tSelectedFeatureCases = await getSelectedCasesFrom(tFeatureDatasetName, tFeatureCollectionName)
 				tSelectedFeatureCases.forEach((iCase: any) => {
-					tFeaturesMap[Number(iCase.id)] = iCase.values.name;
+					// This used to use the caseId, but the featureIDs saved in the training cases are item ids.
+					// I'm using item ids here now, but it's possible they should both use case ids instead.
+					const itemId = iCase.children[0];
+					tFeaturesMap[Number(itemId)] = iCase.values.name;
 				});
 			}
 		}
@@ -276,7 +279,7 @@ export default class TextFeedbackManager {
 			tPredictedLabelAttributeName = this.domainStore.targetStore.targetPredictedLabelAttributeName,
 			tColumnFeatureNames = this.domainStore.featureStore.targetColumnFeatureNames,
 			tConstructedFeatureNames = this.domainStore.featureStore.features.map(iFeature => iFeature.name),
-			tFeaturesMap: {[index:number]:string} = {},
+			tFeaturesMap: Record<number, string> = {},
 			// Get all the selected cases in the target dataset. Some will be results and some will be texts
 			tSelectionListResult: any = await codapInterface.sendRequest({
 				action: 'get',
@@ -461,7 +464,6 @@ export default class TextFeedbackManager {
 				text: tGroup !== kProps[kProps.length - 1] ? '■ ' : '', // Don't add the square if we're in 'blankBlank'
 				color: tColor
 			}
-			// @ts-ignore
 			tClassItems[tGroup].push({
 				type: 'list-item',
 				children: [tSquare].concat(iHighlightFunc(iQuadruple.phrase, iQuadruple.nonNtigramFeatures, iSpecialFeatures))
@@ -474,16 +476,14 @@ export default class TextFeedbackManager {
 
 		// The phrases are all in their groups. Create the array of group objects
 		kProps.forEach(iProp => {
-			// @ts-ignore
-			let tPhrases = tClassItems[iProp];
+			const tPhrases = tClassItems[iProp];
 			if (tPhrases.length !== 0) {
-				let tHeadingItems = [
+				const tHeadingItems = [
 					// @ts-ignore
 					kHeadings[iProp],
 					{
 						type: 'bulleted-list',
-						// @ts-ignore
-						children: tClassItems[iProp]
+						children: tPhrases
 					}];
 				tItems = tItems.concat(tHeadingItems);
 			}

--- a/src/stores/domain_store.ts
+++ b/src/stores/domain_store.ts
@@ -140,7 +140,7 @@ export class DomainStore {
 			values: {
 				features: Feature[]
 			}
-		};
+		}
 		const this_ = this,
 			tFeatureStore = this.featureStore,
 			tNonNgramFeatures = tFeatureStore.features.filter(iFeature => iFeature.info.kind !== 'ngram'),
@@ -202,7 +202,7 @@ export class DomainStore {
 						iFeature.usages.push(iCase.id)
 						const iCaseId = `${iCase.id}`
 						if (!caseUpdateRequests[iCaseId]) {
-							caseUpdateRequests[iCaseId] = {values: {features: []}}
+							caseUpdateRequests[iCaseId] = { values: { features: [] } }
 						}
 						caseUpdateRequests[iCaseId].values.features.push(iFeature)
 					}
@@ -301,7 +301,7 @@ export class DomainStore {
 			const caseUpdateRequestKeys = Object.keys(caseUpdateRequests)
 			if (caseUpdateRequestKeys.length > 0) {
 				const tValues = caseUpdateRequestKeys.map(iIndex => {
-					const iRequest = caseUpdateRequests[iIndex];
+					const iRequest = caseUpdateRequests[iIndex]
 					return {
 						id: iIndex,
 						values: {featureIDs: JSON.stringify(iRequest.values.features.map(iFeature => iFeature.caseID))}

--- a/src/stores/domain_store.ts
+++ b/src/stores/domain_store.ts
@@ -320,6 +320,7 @@ export class DomainStore {
 		if (this.featureStore.tokenMapAlreadyHasUnigrams())
 			return
 		const this_ = this
+		await this.targetStore.updateTargetCases()
 		const tNgramFeatures = this.featureStore.features.filter(iFeature => iFeature.info.kind === 'ngram')
 		await this.guaranteeFeaturesDataset()
 		for (const iNtgramFeature of tNgramFeatures) {

--- a/src/stores/domain_store.ts
+++ b/src/stores/domain_store.ts
@@ -136,14 +136,19 @@ export class DomainStore {
 	}
 
 	async updateNonNtigramFeaturesDataset() {
+		interface UpdateRequest {
+			values: {
+				features: Feature[]
+			}
+		};
 		const this_ = this,
 			tFeatureStore = this.featureStore,
 			tNonNgramFeatures = tFeatureStore.features.filter(iFeature => iFeature.info.kind !== 'ngram'),
 			tTargetStore = this.targetStore,
-			caseUpdateRequests: { values: { features: Feature[] } }[] = [],
+			caseUpdateRequests: Record<string, UpdateRequest> = {},
 			tTargetDatasetName = tTargetStore.targetDatasetInfo.name,
 			tTargetCollectionName = tTargetStore.targetCollectionName
-		let resourceString: string = '',
+		let featureDatasetResourceString: string = '',
 			tFeatureItems: { values: { type: string }, id: string }[] = [],
 			tItemsToDelete: { values: object, id: string }[] = [],
 			tFeaturesToAdd: Feature[] = [],
@@ -152,7 +157,7 @@ export class DomainStore {
 		async function getExistingFeatureItems(): Promise<{ values: any, id: string }[]> {
 			const tItemsRequestResult: any = await codapInterface.sendRequest({
 				action: 'get',
-				resource: `${resourceString}.itemSearch[*]`
+				resource: `${featureDatasetResourceString}.itemSearch[*]`
 			})
 			if (tItemsRequestResult.success)
 				return tItemsRequestResult.values
@@ -170,8 +175,7 @@ export class DomainStore {
 		async function updateFrequenciesUsagesAndFeatureIDs() {
 			const tClassAttrName = this_.targetStore.targetClassAttributeName,
 				tChosenClassKey = this_.targetStore.targetChosenClassColumnKey,
-				tPosClassLabel = this_.targetStore.targetClassNames[tChosenClassKey],
-				tTargetCases = await this_.targetStore.updateTargetCases()
+				tPosClassLabel = this_.targetStore.targetClassNames[tChosenClassKey]
 
 			tNonNgramFeatures.forEach(iFeature => {
 				iFeature.numberInPositive = 0
@@ -179,15 +183,16 @@ export class DomainStore {
 				iFeature.usages = []
 			})
 			/**
-			 * We go through each target case
-			 * 		For each feature, if the case has the feature, we increment that feature's positive or negative count
+			 * We go through each feature
+			 * 		For each target case, if the case has the feature, we increment that feature's positive or negative count
 			 * 			as appropriate
 			 * 		If the feature is present,
 			 * 			- we push the case's ID into the feature's usages
 			 * 			- 	we add the feature's case ID to the array of feature IDs for that case
 			 */
-			tTargetCases.forEach((iCase) => {
-				tNonNgramFeatures.forEach((iFeature) => {
+			const countFeaturePromises = tNonNgramFeatures.map(async (iFeature) => {
+				const tTargetCases = await this_.targetStore.updateTargetCases(`\`${iFeature.name}\`=true`)
+				tTargetCases.forEach(iCase => {
 					if (iCase.values[iFeature.name]) {
 						if (iCase.values[tClassAttrName] === tPosClassLabel) {
 							iFeature.numberInPositive++
@@ -195,17 +200,19 @@ export class DomainStore {
 							iFeature.numberInNegative++
 						}
 						iFeature.usages.push(iCase.id)
-						if (!caseUpdateRequests[iCase.id]) {
-							caseUpdateRequests[iCase.id] = {values: {features: []}}
+						const iCaseId = `${iCase.id}`
+						if (!caseUpdateRequests[iCaseId]) {
+							caseUpdateRequests[iCaseId] = {values: {features: []}}
 						}
-						caseUpdateRequests[iCase.id].values.features.push(iFeature)
+						caseUpdateRequests[iCaseId].values.features.push(iFeature)
 					}
 				})
 			})
+			await Promise.all(countFeaturePromises)
 		}
 
 		if (await this.guaranteeFeaturesDataset()) {
-			resourceString = `dataContext[${tFeatureStore.featureDatasetInfo.datasetID}]`
+			featureDatasetResourceString = `dataContext[${tFeatureStore.featureDatasetInfo.datasetID}]`
 
 			tFeatureItems = (await getExistingFeatureItems()).filter(iItem => iItem.values.type !== 'unigram')
 			await updateFrequenciesUsagesAndFeatureIDs()
@@ -228,7 +235,7 @@ export class DomainStore {
 					tItemsToDelete.map(iItem => {
 						return {
 							action: 'delete',
-							resource: `${resourceString}.itemByID[${iItem.id}]`
+							resource: `${featureDatasetResourceString}.itemByID[${iItem.id}]`
 						}
 					})
 				)
@@ -258,7 +265,7 @@ export class DomainStore {
 				const tCreateResult: any = await codapInterface.sendRequest(
 					{
 						action: 'create',
-						resource: `${resourceString}.collection[${tFeatureStore.featureDatasetInfo.collectionName}].case`,
+						resource: `${featureDatasetResourceString}.collection[${tFeatureStore.featureDatasetInfo.collectionName}].case`,
 						values: tValues
 					}
 				)
@@ -267,7 +274,7 @@ export class DomainStore {
 						tFeaturesToAdd[iIndex].caseID = iValue.id
 						const tGetItemResult: any = await codapInterface.sendRequest({
 							action: 'get',
-							resource: `${resourceString}.itemByCaseID[${iValue.id}]`
+							resource: `${featureDatasetResourceString}.itemByCaseID[${iValue.id}]`
 						})
 						tFeaturesToAdd[iIndex].featureItemID = tGetItemResult.values.id
 					})
@@ -278,7 +285,7 @@ export class DomainStore {
 					tFeaturesToUpdate.map(iFeature => {
 						return {
 							action: 'update',
-							resource: `${resourceString}.itemByID[${iFeature.caseID}]`,
+							resource: `${featureDatasetResourceString}.itemByID[${iFeature.caseID}]`,
 							values: {
 								chosen: iFeature.chosen,
 								name: iFeature.name,
@@ -291,8 +298,10 @@ export class DomainStore {
 			}
 			// We've waited until now to update target cases with feature IDs so that we can be sure
 			//	features do have caseIDs to stash in target cases
-			if (caseUpdateRequests.length > 0) {
-				const tValues = caseUpdateRequests.map((iRequest, iIndex) => {
+			const caseUpdateRequestKeys = Object.keys(caseUpdateRequests)
+			if (caseUpdateRequestKeys.length > 0) {
+				const tValues = caseUpdateRequestKeys.map(iIndex => {
+					const iRequest = caseUpdateRequests[iIndex];
 					return {
 						id: iIndex,
 						values: {featureIDs: JSON.stringify(iRequest.values.features.map(iFeature => iFeature.caseID))}

--- a/src/stores/feature_store.ts
+++ b/src/stores/feature_store.ts
@@ -66,7 +66,7 @@ export class FeatureStore {
 		return tDoneNgram || tDoneSearch || tDoneColumn
 	}
 
-	constructNameFor( iFeature: Feature) {
+	constructNameFor(iFeature: Feature) {
 		if (iFeature.info.kind === 'search') {
 			const tDetails = iFeature.info.details as SearchDetails,
 				tFirstPart = namingAbbreviations[tDetails.where],
@@ -78,11 +78,10 @@ export class FeatureStore {
 			return `${tFirstPart}: ${tSecondPart}`
 		} else if (iFeature.info.kind === 'ngram') {
 			return `single words with frequency ≥ ${iFeature.info.frequencyThreshold}${iFeature.info.ignoreStopWords ? '; ignoring stopwords': ''}`
-		} else if( iFeature.info.kind === 'column')
+		} else if (iFeature.info.kind === 'column')
 			return iFeature.name	// already has column name stashed here
 		else
 			return ''
-
 	}
 
 	getDescriptionFor(iFeature: Feature) {
@@ -160,7 +159,6 @@ export class FeatureStore {
 			default:
 				tType = 'constructed'
 		}
-		tFeature.name = this.constructNameFor(tFeature)
 		tFeature.inProgress = false
 		tFeature.chosen = true
 		tFeature.type = tType

--- a/src/stores/feature_store.ts
+++ b/src/stores/feature_store.ts
@@ -148,8 +148,7 @@ export class FeatureStore {
 		return Boolean(this.features.find(iFeature => iFeature.info.kind === 'ngram'))
 	}
 
-	addFeatureUnderConstruction() {
-		const tFeature = this.featureUnderConstruction
+	addFeatureUnderConstruction(tFeature: Feature) {
 		let tType
 		switch (tFeature.info.kind) {
 			case 'ngram':

--- a/src/stores/target_store.ts
+++ b/src/stores/target_store.ts
@@ -181,10 +181,12 @@ export class TargetStore {
 
 	}
 
-	async updateTargetCases() {
+	async updateTargetCases(formula?: string) {
 		const tTargetDatasetName = this.targetDatasetInfo.name,
 			tCollectionName = this.targetCollectionName,
-			tCaseValues = this.targetAttributeName !== '' ? await getCaseValues(tTargetDatasetName, tCollectionName) : []
+			tCaseValues = this.targetAttributeName !== ''
+				? await getCaseValues(tTargetDatasetName, tCollectionName, formula)
+				: []
 		runInAction(() => {
 			this.targetCases = tCaseValues
 		})


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188150453

This PR updates StoryQ so it works in Codap v3.
- A feature must now be passed to `addFeatureUnderConstruction()`. I'm still not sure why this was not working with the old system, where `addFeatureUnderConstruction` was referencing `FeatureStore.featureUnderConstruction` directly.
- `getCaseValues` can now accept a formula argument. This allows `updateFrequenciesUsagesAndFeatureIDs` in `domain_store.ts` to specify that it only wants cases that fulfill the feature's requirements. I'm still not sure how this was ever working before!
- Cleans up the way headers are constructed in `fillInHeading` in `headings_manager.ts`.
  - `{}` are removed as children, as Slate doesn't like that any more.
  - If no headings are specified, an empty text child `{ text: "" }` is included, because some child is necessary.
- Confusion between case and item ids has been cleared up for features.
- `caseUpdateRequests` has been retyped in `domain_store.ts`. This was previously an array, but it was being used as a dictionary, with all sorts of random numbers as indices. This was making calls like `caseUpdateRequests.length` fail in v3. Now it's a proper dictionary.
- Minor improvements have been made throughout:
  - Updated typing
  - Removed unnecessary lint exceptions
  - Unnecessary `lets` have been turned into `consts`
  - Ambiguous variable names have been changed