### PR TITLE
feat: Extract phrases and emoticons [PT-188319600] [PT-188319636]

### DIFF
--- a/src/stores/feature_store.ts
+++ b/src/stores/feature_store.ts
@@ -70,8 +70,7 @@ export class FeatureStore {
 		if (iFeature.info.kind === 'search') {
 			const tDetails = iFeature.info.details as SearchDetails,
 				tFirstPart = namingAbbreviations[tDetails.where],
-				tMatch = tDetails.freeFormText.match( /\w+/),
-				tSecondPart = tDetails.freeFormText !== '' ? `"${tMatch ? tMatch[0] : ''}"` :
+				tSecondPart = tDetails.freeFormText !== '' ? `"${tDetails.freeFormText.trim()}"` :
 					tDetails.punctuation !== '' ? tDetails.punctuation :
 					tDetails.wordList && tDetails.wordList.datasetName !== '' ? tDetails.wordList.datasetName :
 					tDetails.what === 'any number' ? 'anyNumber' : ''

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -1,4 +1,4 @@
-import {wordTokenizer} from "../lib/one_hot";
+// import {wordTokenizer} from "../lib/one_hot";
 
 /**
  *
@@ -7,7 +7,7 @@ import {wordTokenizer} from "../lib/one_hot";
  * @param iSpecialFeatures - an array of features that don't appear in the text but may appear in iSelectedWords
  */
 export function textToObject( iText:string, iSelectedWords:any, iSpecialFeatures:string[]):any {
-	let segment = '';
+	// let segment = '';
 	let tResultArray:any = [];
 	iSpecialFeatures.forEach( iFeature => {
 		if( iSelectedWords.indexOf( iFeature) >= 0)
@@ -15,6 +15,12 @@ export function textToObject( iText:string, iSelectedWords:any, iSpecialFeatures
 				text: `<${iFeature}> `, bold: true, underlined: true, color: "#0432ff"
 			});
 	});
+
+	// do not highlight text for now
+	tResultArray.push({text: iText});
+
+	/*
+	NOTE: this code is broken and doesn't match phrases or match lists like personal pronoun lists
 
 	let words:string[] = wordTokenizer(iText, false, false);
 	words.forEach((iWord) => {
@@ -39,6 +45,8 @@ export function textToObject( iText:string, iSelectedWords:any, iSpecialFeatures
 	});
 	if( segment !== '')
 		tResultArray.push({ text: segment });
+	*/
+
 	return tResultArray;
 }
 


### PR DESCRIPTION
This updates the plugin to pass the full trimmed text when pattern matching text and then changes the word boundary metacharacters in the pattern to be optional if the text begins/ends with non-word characters.

This also adds a missing escape of any regex characters in the free form text and changes spaces to match multiple spaces.