### PR TITLE
188364196 Fix Text Crash

### DIFF
--- a/src/managers/headings_manager.ts
+++ b/src/managers/headings_manager.ts
@@ -68,7 +68,7 @@ export class HeadingsManager {
 			posBlank: fillInHeading(iPosLabel, null, this.colors.green),
 			blankNeg: fillInHeading(null, iNegLabel, this.colors.orange),
 			blankPos: fillInHeading(null, iPosLabel, this.colors.blue),
-			blankBlank: {}
+			blankBlank: { text: "" }
 		}
 	}
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188364196

In some circumstances, StoryQ was still sending a slate object `{}` to a text tile. In modern slate, `{ text: "" }` is the blank object, and an empty `{}` causes the library to crash.