### PR TITLE
188381232 Include All Tables As Potential Word Lists

### DIFF
--- a/src/stores/feature_store.ts
+++ b/src/stores/feature_store.ts
@@ -267,20 +267,20 @@ export class FeatureStore {
 		})
 		if (tContextListResult?.success) {
 			tContextListResult.values.forEach(async (aValue: any) => {
-				let tCollectionsResult: any = await codapInterface.sendRequest({
+				const tCollectionsResult: any = await codapInterface.sendRequest({
 					action: 'get',
 					resource: `dataContext[${aValue.id}].collectionList`
 				}).catch((reason) => {
 					console.log('unable to get collection list because ' + reason);
 				});
-				if (tCollectionsResult.values.length === 1) {
-					let tAttributesResult: any = await codapInterface.sendRequest({
+				if (tCollectionsResult.values.length >= 1) {
+					const tAttributesResult: any = await codapInterface.sendRequest({
 						action: 'get',
 						resource: `dataContext[${aValue.id}].collection[${tCollectionsResult.values[0].id}].attributeList`
 					}).catch((reason) => {
 						console.log('unable to get attribute list because ' + reason);
 					});
-					if (tAttributesResult.values.length === 1) {
+					if (tAttributesResult.values.length >= 1) {
 						this.wordListSpecs.push({
 							datasetName: aValue.title,
 							firstAttributeName: tAttributesResult.values[0].name


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188381232

Previously, only datasets with a single collection and a single attribute could be used as a word list for the contains feature. This PR removes these restrictions, making all tables potentially word lists. The first attribute of the first collection if more than one is present.