### PR TITLE
Fix: Change training name to update with each keypress [PT-188328210]

### DIFF
--- a/src/components/training_pane.tsx
+++ b/src/components/training_pane.tsx
@@ -78,7 +78,7 @@ export const TrainingPane = observer(class TrainingPane extends Component<Traini
 				return (
 					<TextBox
 						className='sq-fc-part'
-						valueChangeEvent={'enter'}
+						valueChangeEvent={'keyup'}
 						placeholder="Name"
 						onValueChanged={action((e) => {
 							tModel.name = e.value


### PR DESCRIPTION
It was set to change on enter which made it look like the train button was broken if you entered a name and then used the mouse to click on the train button.