### PR TITLE
188381232 Use Attribute from Rightmost Collection as Word List

### DIFF
--- a/src/components/feature_component.tsx
+++ b/src/components/feature_component.tsx
@@ -203,6 +203,7 @@ export const FeatureComponent = observer(class FeatureComponent extends Componen
 									firstAttributeName: tAttributeName
 								}
 							})}
+							value={tContainsDetails?.wordList.datasetName}
 						/>
 					)
 				}

--- a/src/stores/feature_store.ts
+++ b/src/stores/feature_store.ts
@@ -274,9 +274,10 @@ export class FeatureStore {
 					console.log('unable to get collection list because ' + reason);
 				});
 				if (tCollectionsResult.values.length >= 1) {
+					const collectionId = tCollectionsResult.values[tCollectionsResult.values.length - 1].id
 					const tAttributesResult: any = await codapInterface.sendRequest({
 						action: 'get',
-						resource: `dataContext[${aValue.id}].collection[${tCollectionsResult.values[0].id}].attributeList`
+						resource: `dataContext[${aValue.id}].collection[${collectionId}].attributeList`
 					}).catch((reason) => {
 						console.log('unable to get attribute list because ' + reason);
 					});


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/n/projects/2441249/stories/188381232/comments/242731583

This PR follows up on https://github.com/concord-consortium/storyq-codap-plugin/pull/15 by making the first attribute of the _rightmost_ collection be the source of a word list, rather than the _leftmost_ collection.

It also makes the word list dropdown update properly.