### PR TITLE
fix: Emoji key combinations don't enable the feature done button [PT-188413736]

### DIFF
--- a/src/components/feature_component.tsx
+++ b/src/components/feature_component.tsx
@@ -144,7 +144,6 @@ export const FeatureComponent = observer(class FeatureComponent extends Componen
 					return (
 						<TextBox
 							className='sq-fc-part'
-							valueChangeEvent={'keyup'}
 							placeholder="type something here"
 							onValueChanged={action(async (e) => {
 								tContainsDetails.freeFormText = e.value
@@ -163,7 +162,6 @@ export const FeatureComponent = observer(class FeatureComponent extends Componen
 					return (
 						<TextBox
 							className='sq-fc-part'
-							valueChangeEvent={'keyup'}
 							placeholder="punctuation mark"
 							onValueChanged={action(async (e) => {
 								tContainsDetails.punctuation = e.value

--- a/src/components/training_pane.tsx
+++ b/src/components/training_pane.tsx
@@ -78,7 +78,6 @@ export const TrainingPane = observer(class TrainingPane extends Component<Traini
 				return (
 					<TextBox
 						className='sq-fc-part'
-						valueChangeEvent={'keyup'}
 						placeholder="Name"
 						onValueChanged={action((e) => {
 							tModel.name = e.value
@@ -199,7 +198,6 @@ export const TrainingPane = observer(class TrainingPane extends Component<Traini
 					return (
 						<TextBox
 							className='sq-fc-part'
-							valueChangeEvent={'keyup'}
 							placeholder=""
 							hint={SQ.hints.trainingSetupIteration}
 							onValueChanged={action((e) => {

--- a/src/components/ui/text-box.tsx
+++ b/src/components/ui/text-box.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import clsx from "clsx";
 
 type TextBoxChangeEvent = CustomEvent<{value: string}> & {value: string};
 
 interface ITextBoxProps {
   className: string;
-  valueChangeEvent: 'keyup' | 'enter';
   placeholder: string;
   value: string;
   maxLength: number;
@@ -16,31 +15,22 @@ interface ITextBoxProps {
 }
 
 export const TextBox = (props: ITextBoxProps) => {
-  const {className, valueChangeEvent, placeholder, value, maxLength, onValueChanged, hint, width, onFocusOut} = props;
+  const {className, placeholder, value, maxLength, onValueChanged, hint, width, onFocusOut} = props;
   const style: React.CSSProperties = width !== undefined ? {width} : {};
   const [internalValue, setInternalValue] = useState(value);
   const hasValue = internalValue.length > 0;
-  const internalValueRef = useRef(value);
 
   useEffect(() => {
     setInternalValue(value);
   }, [value]);
 
-  const callOnValueChanged = () => {
-    const syntheticEvent = new CustomEvent('customEvent', { detail: { value: internalValueRef.current } }) as any;
-    syntheticEvent.value = internalValueRef.current;
-    onValueChanged(syntheticEvent);
-  }
-
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInternalValue(e.target.value);
-    internalValueRef.current = e.target.value;
-  };
+    const newValue = e.target.value;
+    setInternalValue(newValue);
 
-  const handleKeyUp = (e: React.KeyboardEvent) => {
-    if ((valueChangeEvent === "keyup") || (valueChangeEvent === "enter" && e.key === "Enter")) {
-      callOnValueChanged();
-    }
+    const syntheticEvent = new CustomEvent('customEvent', { detail: { value: newValue } }) as any;
+    syntheticEvent.value = newValue;
+    onValueChanged(syntheticEvent);
   };
 
   return (
@@ -59,7 +49,6 @@ export const TextBox = (props: ITextBoxProps) => {
             value={internalValue}
             onChange={handleChange}
             onBlur={onFocusOut}
-            onKeyUp={handleKeyUp}
           />
           <div className={clsx("ui-placeholder", {"ui-state-invisible": hasValue})}>
             {placeholder}


### PR DESCRIPTION
This simplifies the text box component to remove the unneeded keyup handler that was not being called when the Mac emoji tool (Control+Command+Space) was used to enter a character.

The keyup handler is no longer needed as the valueChangeEvent is always "keyup", whereas in the original UI it used keyup and enter.