### PR TITLE
188381232 Word List on Second Line

### DIFF
--- a/src/components/feature_component.scss
+++ b/src/components/feature_component.scss
@@ -1,0 +1,3 @@
+.word-list-select {
+  min-width: 140px; // Ensures the list is always on a second line
+}

--- a/src/components/feature_component.tsx
+++ b/src/components/feature_component.tsx
@@ -2,7 +2,7 @@
  * This component provides the space for a user to construct and edit a feature
  */
 
-import React, {Component, CSSProperties} from "react";
+import React, {Component} from "react";
 import {
 	Feature,
 	featureDescriptors,
@@ -22,6 +22,8 @@ import {CheckBox} from "./ui/check-box";
 import {SQ} from "../lists/lists";
 import {Button} from "./ui/button";
 import {NumberBox} from "./ui/number-box";
+
+import "./feature_component.scss";
 
 interface FeatureComponentInfo {
 	subscriberIndex: number
@@ -197,17 +199,13 @@ export const FeatureComponent = observer(class FeatureComponent extends Componen
 						}
 					})
 
-					const style: CSSProperties = {
-						display: 'inline-block',
-						minWidth: '140px' // Ensures that the dropdown appears on a second line
-					}
-
 					return (
 						<SelectBox
+							className='word-list-select'
 							dataSource={tLists}
 							defaultValue={tContainsDetails.wordList}
 							placeholder={'choose list'}
-							style={style}
+							style={{display: 'inline-block'}}
 							onValueChange={handleValueChange}
 							value={tContainsDetails?.wordList.datasetName}
 						/>

--- a/src/components/feature_component.tsx
+++ b/src/components/feature_component.tsx
@@ -2,7 +2,7 @@
  * This component provides the space for a user to construct and edit a feature
  */
 
-import React, {Component} from "react";
+import React, {Component, CSSProperties} from "react";
 import {
 	Feature,
 	featureDescriptors,
@@ -182,25 +182,33 @@ export const FeatureComponent = observer(class FeatureComponent extends Componen
 							return iDataset.datasetName;
 						}),
 						tLists = Object.keys(SQ.lists).concat(tWordListDatasetNames)
+
+					const handleValueChange = action((option: string) => {
+						const tWordListSpec = tWordListSpecs.find((iSpec) => {
+							return iSpec.datasetName === option
+						})
+						let tAttributeName = ''
+						if (tWordListSpec) {
+							tAttributeName = tWordListSpec.firstAttributeName
+						}
+						(tFeature.info.details as SearchDetails).wordList = {
+							datasetName: option,
+							firstAttributeName: tAttributeName
+						}
+					})
+
+					const style: CSSProperties = {
+						display: 'inline-block',
+						minWidth: '140px' // Ensures that the dropdown appears on a second line
+					}
+
 					return (
 						<SelectBox
 							dataSource={tLists}
 							defaultValue={tContainsDetails.wordList}
 							placeholder={'choose list'}
-							style={{display: 'inline-block'}}
-							onValueChange={action((option) => {
-								const tWordListSpec = tWordListSpecs.find((iSpec) => {
-									return iSpec.datasetName === option
-								})
-								let tAttributeName = ''
-								if (tWordListSpec) {
-									tAttributeName = tWordListSpec.firstAttributeName
-								}
-								(tFeature.info.details as SearchDetails).wordList = {
-									datasetName: option,
-									firstAttributeName: tAttributeName
-								}
-							})}
+							style={style}
+							onValueChange={handleValueChange}
 							value={tContainsDetails?.wordList.datasetName}
 						/>
 					)


### PR DESCRIPTION
This PR sets a minimum width for the word list dropdown on the features panel. This ensures that the list always appears on a second line, even if the names of the datasets in it are short.