### PR TITLE
fix: Set model weight display precision to 2 decimal places [PT-188364442]

### DIFF
--- a/src/stores/domain_store.ts
+++ b/src/stores/domain_store.ts
@@ -115,7 +115,7 @@ export class DomainStore {
 									parent: tFeatureCollectionName,
 									attrs: [
 										{name: 'model name', type: 'categorical', hidden: false},
-										{name: 'weight', hidden: false}
+										{name: 'weight', precision: 2, hidden: false}
 									]
 								}]
 						}


### PR DESCRIPTION
The default precision seems to be 2 decimal places in CODAP v2 and 3 in CODAP v3 so the precision needs to be set explicitly to 2.