### PR TITLE
Storyq-4 Highlighting

### DIFF
--- a/src/components/feature_component.tsx
+++ b/src/components/feature_component.tsx
@@ -164,24 +164,18 @@ export const FeatureComponent = observer(function FeatureComponent({ feature, sh
 
 	function wordListChoice() {
 		if (featureDetails && featureDetails.what === kWhatOptionList) {
-			const tWordListSpecs = featureStore.wordListSpecs,
-				tWordListDatasetNames = tWordListSpecs.map(iDataset => {
-					return iDataset.datasetName;
-				}),
-				tLists = Object.keys(SQ.lists).concat(tWordListDatasetNames)
+			const tWordListDatasetNames = featureStore.wordListSpecs.map(iDataset => iDataset.datasetName);
+			const tLists = Object.keys(SQ.lists).concat(tWordListDatasetNames);
 
 			const handleValueChange = action((option: string) => {
-				const tWordListSpec = tWordListSpecs.find((iSpec) => {
+				const tWordListSpec = featureStore.wordListSpecs.find((iSpec) => {
 					return iSpec.datasetName === option
 				})
-				let tAttributeName = ''
-				if (tWordListSpec) {
-					tAttributeName = tWordListSpec.firstAttributeName
-				}
+				const tAttributeName = tWordListSpec?.firstAttributeName ?? '';
 				(feature.info.details as SearchDetails).wordList = {
 					datasetName: option,
 					firstAttributeName: tAttributeName
-				}
+				};
 			})
 
 			return (

--- a/src/lib/one_hot.ts
+++ b/src/lib/one_hot.ts
@@ -34,7 +34,7 @@ export const wordTokenizer = (text: string, ignoreStopWords: boolean, ignorePunc
 		let emojiconsOrWords = `${emoticons}|${emojis}|${words}`;
 		let tExpressionPattern = ignorePunctuation ? emojiconsOrWords : `${emojiconsOrWords}|[,!:@#$%^&*()\\-_[\\]{};'".<>/?\`~]|\\d+`;
 		let tExpression = new RegExp(tExpressionPattern, 'gu');
-		let tWords: RegExpMatchArray | [] = text.toLowerCase().match(tExpression) || [];
+		let tWords: RegExpMatchArray | [] = text.match(tExpression) || [];
 		tWords.forEach((aWord) => {
 			if (!ignoreStopWords || !stopWords[aWord])
 				tokens.push(aWord);

--- a/src/lib/one_hot.ts
+++ b/src/lib/one_hot.ts
@@ -23,18 +23,34 @@ import { emoticons } from "./emoticons";
 
 export const kMaxTokens = 1000;
 
+const words = `(\\w+['’]{0,1}\\w*)`;
+const emojis = `[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{25A0}-\u{2BFF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F900}-\u{1F9FF}\u{1FA70}-\u{1FAFF}]`;
+const whitespace = /\s+/.source;
+const punctuation = `[,!:@#$%^&*()\\-_[\\]{};'".<>/?\`~]|\\d+`;
+const emojiconsOrWords = `${emoticons}|${emojis}|${words}`;
+
+/**
+ * Convert the given string into an array of tokens, maintaining case. Tokens include whitespace so the
+ * text can be recreated by joining the tokens.
+ */
+export function allTokenizer(text: string) {
+	if (text) {
+		const tExpressionPattern = `${emojiconsOrWords}|${whitespace}|${punctuation}`;
+		const tExpression = new RegExp(tExpressionPattern, 'gu');
+		return text.match(tExpression) || [];
+	}
+	return [];
+}
+
 /**
  * Convert the given string into an array of lowercase words.
  */
 export const wordTokenizer = (text: string, ignoreStopWords: boolean, ignorePunctuation: boolean): string[] => {
-	let tokens: string[] = [];
+	const tokens: string[] = [];
 	if (text) {
-		let words = `(\\w+['’]{0,1}\\w*)`;
-		let emojis = `[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{25A0}-\u{2BFF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F900}-\u{1F9FF}\u{1FA70}-\u{1FAFF}]`;
-		let emojiconsOrWords = `${emoticons}|${emojis}|${words}`;
-		let tExpressionPattern = ignorePunctuation ? emojiconsOrWords : `${emojiconsOrWords}|[,!:@#$%^&*()\\-_[\\]{};'".<>/?\`~]|\\d+`;
-		let tExpression = new RegExp(tExpressionPattern, 'gu');
-		let tWords: RegExpMatchArray | [] = text.match(tExpression) || [];
+		const tExpressionPattern = ignorePunctuation ? emojiconsOrWords : `${emojiconsOrWords}|${punctuation}`;
+		const tExpression = new RegExp(tExpressionPattern, 'gu');
+		const tWords: RegExpMatchArray | [] = text.toLowerCase().match(tExpression) || [];
 		tWords.forEach((aWord) => {
 			if (!ignoreStopWords || !stopWords[aWord])
 				tokens.push(aWord);

--- a/src/lib/one_hot.ts
+++ b/src/lib/one_hot.ts
@@ -83,14 +83,6 @@ export interface Document {
  * encoding of those documents consisting of an array representing the presence or absence
  * of each of the "tokens" in the document set.
  * For StoryQ, with each token we keep track of the document caseIDs in which it occurs.
- * @result
- * {
- *   oneHotResult:{ oneHotExample:number[], class:string }[],
- *   tokenMap: [key:string]: { token:string, type:string, count:number, index:number,
- *			caseIDs:number[], weight:number|null, featureCaseID:number|null },
- *	 tokenArray: { token:string, count:number, index:number,
- *	 		caseIDs:number[], weight:number|null, featureCaseID:number}[]
- * }
  */
 export function oneHot(config: OneHotConfig, documents: Document[]) {
 	const tTokenMapIsPredefined = !!config.tokenMap;
@@ -193,9 +185,5 @@ export function oneHot(config: OneHotConfig, documents: Document[]) {
 		return { oneHotExample: tVector, class: aDoc.class };
 	});
 
-	return {
-		oneHotResult: oneHotArray,
-		tokenMap,
-		tokenArray
-	};
+	return { oneHotResult: oneHotArray, tokenMap, tokenArray };
 }

--- a/src/lib/one_hot.ts
+++ b/src/lib/one_hot.ts
@@ -17,8 +17,10 @@
 //  limitations under the License.
 // ==========================================================================
 
-import {stopWords} from "./stop_words";
-import {Feature, getNewToken, kTokenTypeConstructed, kTokenTypeUnigram, Token, TokenMap} from "../stores/store_types_and_constants";
+import { stopWords } from "./stop_words";
+import {
+	Feature, getNewToken, kTokenTypeConstructed, kTokenTypeUnigram, TokenMap
+} from "../stores/store_types_and_constants";
 import { emoticons } from "./emoticons";
 
 export const kMaxTokens = 1000;

--- a/src/lib/stop_words.ts
+++ b/src/lib/stop_words.ts
@@ -1,4 +1,4 @@
-export const stopWords: { [key: string]:{} } = {
+export const stopWords: Record<string, boolean> = {
   "a": true,
   "about": true,
   "above": true,

--- a/src/lists/lists.ts
+++ b/src/lists/lists.ts
@@ -1,4 +1,8 @@
-export const SQ: { lists: { [key: string]: string[] }, hints: { [key:string]:string} } = {
+interface ISQ {
+	lists: Record<string, string[]>;
+	hints: Record<string, string>;
+}
+export const SQ: ISQ = {
 	lists: {
 		personalPronouns: ["I", "you", "he", "she", "it", "we", "they", "them", "us", "him", "her", "his",
 			"hers", "its", "theirs", "our", "your"],

--- a/src/managers/model_manager.ts
+++ b/src/managers/model_manager.ts
@@ -5,7 +5,7 @@ import { action, runInAction } from "mobx";
 import { deselectAllCasesIn } from "../lib/codap-helper";
 import codapInterface from "../lib/CodapInterface";
 import { LogisticRegression } from "../lib/jsregression";
-import { oneHot } from "../lib/one_hot";
+import { Document, oneHot } from "../lib/one_hot";
 import { domainStore } from "../stores/domain_store";
 import { featureStore } from "../stores/feature_store";
 import { Feature, kFeatureKindNgram, NgramDetails, StoredAIModel, Token } from "../stores/store_types_and_constants";
@@ -318,10 +318,7 @@ export class ModelManager {
 			tNgramFeatures = featureStore.getChosenFeatures().filter(iFeature => iFeature.info.kind === kFeatureKindNgram),
 			tUnigramFeature = tNgramFeatures.find(iFeature => (iFeature.info.details as NgramDetails).n === 'uni'),
 			tPositiveClassName = targetStore.getClassName('positive'),
-			tDocuments: {
-				example: string, class: string, caseID: number,
-				columnFeatures: { [key: string]: number | boolean }
-			}[] = [],
+			tDocuments: Document[] = [],
 			tLogisticModel = trainingStore.model.logisticModel
 
 		async function setup() {

--- a/src/managers/text_feedback_manager.ts
+++ b/src/managers/text_feedback_manager.ts
@@ -441,7 +441,7 @@ export class TextFeedbackManager {
 		let tItems: Descendant[] = [];
 
 
-		function addOnePhrase(iQuadruple: PhraseQuadruple) {
+		async function addOnePhrase(iQuadruple: PhraseQuadruple) {
 			const kLabels: ClassLabel = kHeadingsManager.classLabels;
 
 			let tGroup: string,
@@ -502,12 +502,14 @@ export class TextFeedbackManager {
 			});
 			if (!texts[tGroup]) texts[tGroup] = [];
 			texts[tGroup].push({
-				textParts: highlightFeatures(iQuadruple.phrase, iQuadruple.nonNtigramFeatures),
+				textParts: await highlightFeatures(iQuadruple.phrase, iQuadruple.nonNtigramFeatures),
 				index: iQuadruple.index
 			});
 		}
 
-		iPhraseQuadruples.forEach(iTriple => addOnePhrase(iTriple));
+		for (const iTriple of iPhraseQuadruples) {
+			await addOnePhrase(iTriple);
+		}
 
 		// The phrases are all in their groups. Create the array of group objects
 		textStore.setTextSections([]);

--- a/src/stores/feature_store.ts
+++ b/src/stores/feature_store.ts
@@ -6,7 +6,8 @@
 import { makeAutoObservable, toJS } from 'mobx'
 import codapInterface from "../lib/CodapInterface";
 import {
-	GetAttributeListResponse, GetCaseFormulaSearchResponse, GetCollectionListResponse, GetDataContextListResponse
+	GetAttributeListResponse, GetCaseFormulaSearchResponse, GetCollectionListResponse, GetDataContextListResponse,
+	GetItemSearchResponse
 } from '../types/codap-api-types';
 import {
 	Feature, FeatureType, getStarterFeature, kFeatureKindColumn, kFeatureKindNgram, kFeatureKindSearch,
@@ -94,6 +95,19 @@ export class FeatureStore {
 			this.setFeatureUnderConstruction(json.featureUnderConstruction || getStarterFeature());
 			this.setTokenMap(json.tokenMap || {});
 			this.setTargetColumnFeatureNames(json.targetColumnFeatureNames || []);
+		}
+	}
+
+	async getWordListFromDatasetName(datasetName: string) {
+		const attributeName = this.wordListSpecs.find(iSpec => iSpec.datasetName === datasetName)?.firstAttributeName;
+		if (!attributeName) return;
+
+		const result = await codapInterface.sendRequest({
+			action: 'get',
+			resource: `dataContext[${datasetName}].itemSearch[*]`
+		}) as GetItemSearchResponse;
+		if (result.success && result.values) {
+			return result.values.map(item => item.values[attributeName]);
 		}
 	}
 

--- a/src/stores/store_types_and_constants.ts
+++ b/src/stores/store_types_and_constants.ts
@@ -286,6 +286,20 @@ export interface Token {
 	type: TokenType
 	weight: number | null
 }
+export function getNewToken(initialValues: Partial<Token>) {
+	return {
+		caseIDs: [],
+		count: 1,
+		featureCaseID: null,
+		index: -1,
+		numNegative: 0,
+		numPositive: 0,
+		token: '',
+		type: kTokenTypeConstructed as TokenType,
+		weight: null,
+		...initialValues
+	};
+}
 
 export type TokenMap = Record<string, Token>;
 

--- a/src/stores/store_types_and_constants.ts
+++ b/src/stores/store_types_and_constants.ts
@@ -228,11 +228,6 @@ export function getStarterFeature(): Feature {
 	};
 }
 
-export interface WordListSpec {
-	datasetName: string,
-	firstAttributeName: string
-}
-
 export interface TrainingResult {
 	accuracy: number
 	constantWeightTerm: number

--- a/src/utilities/utilities.test.ts
+++ b/src/utilities/utilities.test.ts
@@ -1,0 +1,77 @@
+import { highlightFeatures } from "./utilities";
+
+describe("highlightFeatures", () => {
+  it("should handle no features", async () => {
+    const text = `Test text.`;
+    const selectedFeatures: string[] = [];
+    const result = await highlightFeatures(text, selectedFeatures);
+    expect(result).toEqual([
+      { text }
+    ]);
+  });
+
+  it("should handle a single word feature", async () => {
+    const text = `Test text.`;
+    const selectedFeatures = ["text"];
+    const result = await highlightFeatures(text, selectedFeatures);
+    expect(result).toEqual([
+      { text: "Test " },
+      { text: "text", classNames: ["highlighted"] },
+      { text: "." }
+    ]);
+  });
+
+  it("should handle multiple single word features", async () => {
+    const text = `Test text.`;
+    const selectedFeatures = ["Test", "text"];
+    const result = await highlightFeatures(text, selectedFeatures);
+    expect(result).toEqual([
+      { text: "Test", classNames: ["highlighted"] },
+      { text: " " },
+      { text: "text", classNames: ["highlighted"] },
+      { text: "." }
+    ]);
+  });
+
+  it("should handle a single phrase feature", async () => {
+    const text = `Test text.`;
+    const selectedFeatures = ["Test text"];
+    const result = await highlightFeatures(text, selectedFeatures);
+    expect(result).toEqual([
+      { text: "Test text", classNames: ["highlighted"] },
+      { text: "." }
+    ]);
+  });
+
+  it("should handle a single contain feature", async () => {
+    const text = `Test text.`;
+    const selectedFeatures = [`contain: "text"`];
+    const result = await highlightFeatures(text, selectedFeatures);
+    expect(result).toEqual([
+      { text: "Test " },
+      { text: "text", classNames: ["highlighted"] },
+      { text: "." }
+    ]);
+  });
+
+  it("should handle a single count feature", async () => {
+    const text = `Test text.`;
+    const selectedFeatures = [`count: "test"`];
+    const result = await highlightFeatures(text, selectedFeatures);
+    expect(result).toEqual([
+      { text: "Test", classNames: ["highlighted"] },
+      { text: " text." }
+    ]);
+  });
+
+  it("should handle a list feature", async () => {
+    const text = `I love you`;
+    const selectedFeatures = [`contain: personalPronouns`];
+    const result = await highlightFeatures(text, selectedFeatures);
+    expect(result).toEqual([
+      { text: "I", classNames: ["highlighted"] },
+      { text: " love " },
+      { text: "you", classNames: ["highlighted"] }
+    ]);
+  });
+});

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -1,5 +1,5 @@
 import { Descendant } from "@concord-consortium/slate-editor";
-import { wordTokenizer } from "../lib/one_hot";
+import { allTokenizer } from "../lib/one_hot";
 import { ITextPart } from "../stores/store_types_and_constants";
 
 export type HighlightFunction =
@@ -22,7 +22,7 @@ export function textToObject(iText: string, iSelectedWords: (string | number)[],
 	});
 
 	// NOTE: this code isn't perfect and doesn't match phrases or match lists like personal pronoun lists
-	const words = wordTokenizer(iText, false, false);
+	const words = allTokenizer(iText);
 	words.forEach((iWord) => {
 		let tRawWord = iWord.toLowerCase();
 		const containedWords = iSelectedWords.map(selectedWord => {
@@ -45,12 +45,9 @@ export function textToObject(iText: string, iSelectedWords: (string | number)[],
 			tResultArray.push({
 				text: iWord, bold: true, underlined: true, color: "#000000"
 			});
-			tResultArray.push({
-				text: ' '
-			})
 		}
 		else {
-			segment += iWord + ' ';
+			segment += iWord;
 		}
 	});
 
@@ -64,7 +61,7 @@ export function highlightFeatures(text: string, selectedFeatures: (string | numb
 	const textParts: ITextPart[] = [];
 
 	// NOTE: this code isn't perfect and doesn't match phrases or match lists like personal pronoun lists
-	const words = wordTokenizer(text, false, false);
+	const words = allTokenizer(text);
 	const targetWords = selectedFeatures.map(selectedWord => {
 		// Strip out the word from strings like 'contain: "word"' and 'count: "word"'
 		const _containedWord = typeof selectedWord === "string" && selectedWord.match(/contain: "([^"]+)"/);
@@ -85,11 +82,8 @@ export function highlightFeatures(text: string, selectedFeatures: (string | numb
 			textParts.push({
 				text: word, classNames: ["highlighted"]
 			});
-			textParts.push({
-				text: ' '
-			})
 		} else {
-			segment += word + ' ';
+			segment += word;
 		}
 	});
 

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -124,12 +124,6 @@ export async function highlightFeatures(text: string, selectedFeatures: (string 
 
 		let foundMatch = false;
 
-		// Look for matches with single words.
-		if (targetWords.includes(word.toLowerCase())) {
-			foundMatch = true;
-			highlightWord(word);
-		}
-
 		// Look for matches with phrases.
 		targetPhrases.forEach(phrase => {
 			if (foundMatch) return;
@@ -152,6 +146,12 @@ export async function highlightFeatures(text: string, selectedFeatures: (string 
 				}
 			});
 		});
+
+		// Look for matches with single words.
+		if (!foundMatch && targetWords.includes(word.toLowerCase())) {
+			foundMatch = true;
+			highlightWord(word);
+		}
 
 		// If it's not a match, add it to the current segment with basic text.
 		if (!foundMatch) {


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/STORYQ-4

This PR improves highlighting of keywords in the new plugin text pane. The main improvement is that phrases are now highlighted, rather than just single words, but there are other improvements.
- Capitalization and whitespace is now preserved when highlighting.
- Words from word list features are now highlighted. These can be from built in word lists (`personalPronouns` and `prepositions`) or word lists from datasets (which just take the text in the first attribute).

Some relevant details related to the above changes:
- `allTokenizer` has been added to `one_hot.ts`, which breaks a text into tokens and whitespace. This is used by functions that display text to the user, rather than `wordTokenizer`, which is still used by some other functions.
- Most of the work to highlight text occurs in `highlightFeatures`, which has changed quite a bit but should be easier to understand now.
  - One big change here is that this function is now `async`. This is required because it might need to request a word list from a dataset from Codap. This change has ripple effects throughout the codebase.
- The first jest test has been added to this codebase, to test `highlightFeatures`! Yay!

Additionally, I cleaned up a several other parts of the codebase. The most notable of these is `oneHot`, which involved a lot of changed lines as well as improved typing that shows up elsewhere.