### PR TITLE
Storyq-11 More Text Pane

### DIFF
--- a/cypress/e2e/workspace.test.ts
+++ b/cypress/e2e/workspace.test.ts
@@ -9,5 +9,29 @@ context("Test the overall app", () => {
     it("renders with text", () => {
       ae.getWelcome().invoke("text").should("include", "Welcome to StoryQ!");
     });
+
+    it("renders main and text panes, which can be collapsed", () => {
+      ae.getApp().should("exist");
+      ae.getTextPane().should("exist");
+      ae.getCollapseButtons().should("have.length", 2);
+
+      // Collapse the main pane
+      ae.getCollapseButtons().first().click();
+      ae.getApp().should("not.exist");
+      ae.getTextPane().should("exist");
+      ae.getCollapseButtons().should("have.length", 1);
+
+      // Restore main pane
+      ae.getCollapseButtons().first().click();
+      ae.getApp().should("exist");
+      ae.getTextPane().should("exist");
+      ae.getCollapseButtons().should("have.length", 2);
+
+      // Collapse text pane
+      ae.getCollapseButtons().last().click();
+      ae.getApp().should("exist");
+      ae.getTextPane().should("not.exist");
+      ae.getCollapseButtons().should("have.length", 1);
+    });
   });
 });

--- a/cypress/support/elements/app-elements.ts
+++ b/cypress/support/elements/app-elements.ts
@@ -4,5 +4,11 @@ export const AppElements = {
   },
   getWelcome() {
     return cy.get(".storyq .ui-tabpanel-container .sq-welcome")
+  },
+  getTextPane() {
+    return cy.get(".text-pane");
+  },
+  getCollapseButtons() {
+    return cy.get(".collapse-button");
   }
 };

--- a/src/assets/arrow-icon.svg
+++ b/src/assets/arrow-icon.svg
@@ -1,0 +1,16 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd">
+        <path d="M0 24h24V0H0z"/>
+        <path
+            class="arrow-outline"
+            fill="#ccc"
+            fill-rule="nonzero" d="M21.524 15.861 12 6.337l-1.06 1.06L5.036 13.3l-2.561 2.561z"
+        />
+        <path
+            class="arrow-center"
+            fill="#ccc"
+            fill-rule="nonzero"
+            d="M6.097 14.361 12 8.458l5.903 5.903z"
+        />
+    </g>
+</svg>

--- a/src/components/collapse-button.scss
+++ b/src/components/collapse-button.scss
@@ -1,0 +1,26 @@
+.collapse-button {
+  align-items: center;
+  background-color: #eee;
+  border: 1px solid #ccc;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  padding: 0;
+  width: 16px;
+
+  &:hover {
+    background-color: #e4e4e4;
+  }
+
+  .arrow-icon {
+    &.left {
+      rotate: -90deg;
+    }
+
+    &.right {
+      rotate: 90deg;
+    }
+  }
+}

--- a/src/components/collapse-button.tsx
+++ b/src/components/collapse-button.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { clsx } from "clsx";
+import { ReactComponent as ArrowIcon } from "../assets/arrow-icon.svg";
+
+import "./collapse-button.scss";
+
+export const collapseButtonWidth = 16;
+
+interface ICollapseButtonProps {
+  direction: "left" | "right";
+  onClick: () => void;
+}
+export function CollapseButton({ direction, onClick }: ICollapseButtonProps) {
+  return (
+    <button className="collapse-button" onClick={onClick}>
+      <ArrowIcon className={clsx("arrow-icon", direction)} />
+    </button>
+  );
+}

--- a/src/components/storyq.tsx
+++ b/src/components/storyq.tsx
@@ -9,6 +9,7 @@ import { kStoryQPluginName } from "../stores/store_types_and_constants";
 import { targetStore } from '../stores/target_store';
 import { testingStore } from "../stores/testing_store";
 import { IUiStoreJSON, uiStore } from "../stores/ui_store";
+import { CollapseButton, collapseButtonWidth } from "./collapse-button";
 import { FeaturePanel } from "./feature_panel";
 import { TargetPanel } from "./target_panel";
 import { TestingPanel, kNonePresent } from "./testing_panel";
@@ -20,6 +21,8 @@ import { TabPanel } from './ui/tab-panel';
 import '../storyq.css';
 import '../styles/light.compact.css';
 
+const paneWidth = 430;
+
 interface IStorage {
 	domainStore: IDomainStoreJSON;
 	uiStore: IUiStoreJSON;
@@ -30,7 +33,7 @@ const Storyq = observer(class Storyq extends Component<IStoryqProps, {}> {
 		private kPluginName = kStoryQPluginName;
 		private kVersion = "2.18.0";
 		private kInitialDimensions = {
-			width: 860,
+			width: (paneWidth + collapseButtonWidth) * 2,
 			height: 420
 		};
 		private testingManager: TestingManager;
@@ -87,29 +90,39 @@ const Storyq = observer(class Storyq extends Component<IStoryqProps, {}> {
 		}
 
 		public render() {
+			const leftDirection = uiStore.showStoryQPanel ? "left" : "right";
+			const rightDirection = uiStore.showTextPanel ? "right" : "left";
+			const onLeftButtonClick = () => uiStore.showStoryQPanel
+				? uiStore.setShowStoryQPanel(false) : uiStore.setShowStoryQPanel(true);
+			const onRightButtonClick = () => uiStore.showTextPanel
+				? uiStore.setShowTextPanel(false) : uiStore.setShowTextPanel(true);
 			return (
 				<div className="storyq-container">
-					<div className="storyq">
-						<TabPanel
-							id='tabPanel'
-							selectedIndex={uiStore.tabPanelSelectedIndex}
-							onSelectionChanged={(index: number) => this.handleSelectionChanged(index)}
-						>
-							<Item title='Setup' text='Specify the text data you want to work with'>
-								<TargetPanel />
-							</Item>
-							<Item title='Features' disabled={!domainStore.featuresPanelCanBeEnabled()}>
-								<FeaturePanel />
-							</Item>
-							<Item title='Training' disabled={!domainStore.trainingPanelCanBeEnabled()}>
-								<TrainingPanel />
-							</Item>
-							<Item title='Testing' disabled={!domainStore.testingPanelCanBeEnabled()}>
-								<TestingPanel testingManager={this.testingManager} />
-							</Item>
-						</TabPanel>
-					</div>
-					<TextPane />
+					{uiStore.showStoryQPanel && (
+						<div className="storyq">
+							<TabPanel
+								id='tabPanel'
+								selectedIndex={uiStore.tabPanelSelectedIndex}
+								onSelectionChanged={(index: number) => this.handleSelectionChanged(index)}
+							>
+								<Item title='Setup' text='Specify the text data you want to work with'>
+									<TargetPanel />
+								</Item>
+								<Item title='Features' disabled={!domainStore.featuresPanelCanBeEnabled()}>
+									<FeaturePanel />
+								</Item>
+								<Item title='Training' disabled={!domainStore.trainingPanelCanBeEnabled()}>
+									<TrainingPanel />
+								</Item>
+								<Item title='Testing' disabled={!domainStore.testingPanelCanBeEnabled()}>
+									<TestingPanel testingManager={this.testingManager} />
+								</Item>
+							</TabPanel>
+						</div>
+					)}
+					{uiStore.showTextPanel && <CollapseButton direction={leftDirection} onClick={onLeftButtonClick} />}
+					{uiStore.showStoryQPanel && <CollapseButton direction={rightDirection} onClick={onRightButtonClick} />}
+					{uiStore.showTextPanel && <TextPane />}
 				</div>
 			);
 		}

--- a/src/components/text-pane/text-pane.scss
+++ b/src/components/text-pane/text-pane.scss
@@ -3,14 +3,17 @@
   width: 429px;
 
   .text-title {
+    align-items: center;
+    display: flex;
     font-size: 18px;
     font-weight: bold;
-    margin: 6px 0;
-    text-align: center;
+    justify-content: center;
     width: 100%;
   }
 
   .text-container {
+    display: flex;
+    flex-direction: column;
     overflow-y: scroll;
     padding: 4px;
   }

--- a/src/components/text-pane/text-pane.tsx
+++ b/src/components/text-pane/text-pane.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { observer } from "mobx-react";
 import { textStore } from "../../stores/text_store";
-import { TextSection } from "./text-section";
+import { TextSection, textSectionTitleHeight } from "./text-section";
 
 import "./text-pane.scss";
 
@@ -10,7 +10,10 @@ const titleHeight = 22;
 const containerHeight = paneHeight - titleHeight;
 
 export const TextPane = observer(function TextPane() {
-  const sectionHeight = containerHeight / textStore.textSections.length;
+  const visibleTextSectionCount = textStore.textSections.filter(textSection => !textSection.hidden).length;
+  const textHeight = containerHeight - textStore.textSections.length * textSectionTitleHeight;
+  const sectionHeight = textHeight / visibleTextSectionCount;
+
   return (
     <div className="text-pane" style={{ height: paneHeight }}>
       <p className="text-title" style={{ height: titleHeight }}>
@@ -19,8 +22,8 @@ export const TextPane = observer(function TextPane() {
       <div className="text-container" style={{ height: containerHeight }}>
         {textStore.textSections.map(textSection => (
           <TextSection
-            height={sectionHeight}
-            key={`section-${textSection.title?.actual}-${textSection.title?.predicted}`}
+            key={textStore.getTextSectionId(textSection)}
+            textHeight={sectionHeight}
             textSection={textSection}
           />
         ))}

--- a/src/components/text-pane/text-pane.tsx
+++ b/src/components/text-pane/text-pane.tsx
@@ -6,8 +6,9 @@ import { TextSection, textSectionTitleHeight } from "./text-section";
 import "./text-pane.scss";
 
 const paneHeight = 395;
-const titleHeight = 22;
-const containerHeight = paneHeight - titleHeight;
+const titleHeight = 34;
+const containerVerticalPadding = 4;
+const containerHeight = paneHeight - titleHeight - containerVerticalPadding * 2;
 
 export const TextPane = observer(function TextPane() {
   const visibleTextSectionCount = textStore.textSections.filter(textSection => !textSection.hidden).length;
@@ -16,9 +17,9 @@ export const TextPane = observer(function TextPane() {
 
   return (
     <div className="text-pane" style={{ height: paneHeight }}>
-      <p className="text-title" style={{ height: titleHeight }}>
+      <div className="text-title" style={{ height: titleHeight }}>
         {textStore.textComponentTitle}
-      </p>
+      </div>
       <div className="text-container" style={{ height: containerHeight }}>
         {textStore.textSections.map(textSection => (
           <TextSection

--- a/src/components/text-pane/text-section.scss
+++ b/src/components/text-pane/text-section.scss
@@ -2,11 +2,11 @@
   .text-section-title {
     align-items: center;
     display: flex;
-    font-size: 16px;
-    font-weight: 600;
+    font-size: 14px;
+    font-weight: 700;
 
     .label {
-      font-weight: 700;
+      font-weight: 800;
     }
   }
 

--- a/src/components/text-pane/text-section.scss
+++ b/src/components/text-pane/text-section.scss
@@ -9,6 +9,33 @@
     .label {
       font-weight: 800;
     }
+
+    .hide-button {
+      align-items: center;
+      background-color: rgba(0, 0, 0, 0);
+      border: none;
+      cursor: pointer;
+      display: flex;
+      justify-content: center;
+      margin-right: 5px; // To move the button away from the resize handle
+      padding: 0;
+
+      &.hidden {
+        svg {
+          rotate: 180deg;
+        }
+      }
+
+      &:hover {
+        .arrow-outline {
+          fill: #ddd;
+        }
+
+        .arrow-center {
+          fill: #ddd;
+        }
+      }
+    }
   }
 
   .text-section-text {

--- a/src/components/text-pane/text-section.scss
+++ b/src/components/text-pane/text-section.scss
@@ -4,6 +4,7 @@
     display: flex;
     font-size: 14px;
     font-weight: 700;
+    justify-content: space-between;
 
     .label {
       font-weight: 800;

--- a/src/components/text-pane/text-section.tsx
+++ b/src/components/text-pane/text-section.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { clsx } from "clsx";
 import { ITextSection, ITextSectionTitle } from "../../stores/store_types_and_constants";
+import { textStore } from "../../stores/text_store";
 
 import "./text-section.scss";
 
@@ -13,7 +14,7 @@ function TextSectionTitle({ count, title }: ITextSectionTitleProps) {
 
   const { actual, predicted, color } = title;
   return (
-    <>
+    <span>
       {actual && (
         <span>
           True label: <span className="label" style={{ color }}>{actual}</span>
@@ -22,40 +23,43 @@ function TextSectionTitle({ count, title }: ITextSectionTitleProps) {
       )}
       {predicted && <span>Predicted label: <span className="label" style={{ color }}>{predicted}</span></span>}
       <span>&nbsp;</span>{`(${count} case${count === 1 ? "" : "s"})`}
-    </>
+    </span>
   );
 }
 
-const titleHeight = 26;
+export const textSectionTitleHeight = 26;
 
 interface ITextSectionProps {
-  height: number;
+  textHeight: number;
   textSection: ITextSection;
 }
-export function TextSection({ height, textSection }: ITextSectionProps) {
-  const textHeight = height - titleHeight;
+export function TextSection({ textHeight, textSection }: ITextSectionProps) {
+  const height = textSectionTitleHeight + (!textSection.hidden ? textHeight : 0);
   return (
     <div className="text-section" style={{ height }}>
-      <p className="text-section-title" style={{ height: titleHeight }}>
+      <div className="text-section-title" style={{ height: textSectionTitleHeight }}>
         <TextSectionTitle count={textSection.text.length} title={textSection.title} />
-      </p>
-      <div className="text-section-text" style={{ height: textHeight }}>
-        {textSection.text.map(text => {
-          const indexString = text.index != null ? `${text.index + 1}. ` : "";
-          return (
-            <div className="phrase-row" key={indexString}>
-              <div className="phrase-index">{indexString}</div>
-              <div className="phrase">
-                {text.textParts.map((part, index) => (
-                  <span className={clsx(part.classNames)} key={`${index}-${part.text}`}>
-                    {part.text}
-                  </span>
-                ))}
-              </div>
-            </div>
-          );
-        })}
+        <button onClick={() => textStore.toggleTextSectionVisibility(textSection)}>X</button>
       </div>
+      {!textSection.hidden && (
+        <div className="text-section-text" style={{ height: textHeight }}>
+          {textSection.text.map(text => {
+            const indexString = text.index != null ? `${text.index + 1}. ` : "";
+            return (
+              <div className="phrase-row" key={indexString}>
+                <div className="phrase-index">{indexString}</div>
+                <div className="phrase">
+                  {text.textParts.map((part, index) => (
+                    <span className={clsx(part.classNames)} key={`${index}-${part.text}`}>
+                      {part.text}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/text-pane/text-section.tsx
+++ b/src/components/text-pane/text-section.tsx
@@ -5,16 +5,23 @@ import { ITextSection, ITextSectionTitle } from "../../stores/store_types_and_co
 import "./text-section.scss";
 
 interface ITextSectionTitleProps {
+  count: number;
   title?: ITextSectionTitle;
 }
-function TextSectionTitle({ title }: ITextSectionTitleProps) {
+function TextSectionTitle({ count, title }: ITextSectionTitleProps) {
   if (!title) return null;
 
   const { actual, predicted, color } = title;
   return (
     <>
-      {actual && <span>True label: <span className="label" style={{ color }}>{actual}</span>{predicted && ", "}</span>}
+      {actual && (
+        <span>
+          True label: <span className="label" style={{ color }}>{actual}</span>
+          {predicted && <span>,&nbsp;</span>}
+        </span>
+      )}
       {predicted && <span>Predicted label: <span className="label" style={{ color }}>{predicted}</span></span>}
+      <span>&nbsp;</span>{`(${count} case${count === 1 ? "" : "s"})`}
     </>
   );
 }
@@ -30,7 +37,7 @@ export function TextSection({ height, textSection }: ITextSectionProps) {
   return (
     <div className="text-section" style={{ height }}>
       <p className="text-section-title" style={{ height: titleHeight }}>
-        <TextSectionTitle title={textSection.title} />
+        <TextSectionTitle count={textSection.text.length} title={textSection.title} />
       </p>
       <div className="text-section-text" style={{ height: textHeight }}>
         {textSection.text.map(text => {

--- a/src/components/text-pane/text-section.tsx
+++ b/src/components/text-pane/text-section.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import { clsx } from "clsx";
+import { ReactComponent as ArrowIcon } from "../../assets/arrow-icon.svg";
 import { ITextSection, ITextSectionTitle } from "../../stores/store_types_and_constants";
 import { textStore } from "../../stores/text_store";
 
 import "./text-section.scss";
+
+export const textSectionTitleHeight = 26;
 
 interface ITextSectionTitleProps {
   count: number;
@@ -27,23 +30,27 @@ function TextSectionTitle({ count, title }: ITextSectionTitleProps) {
   );
 }
 
-export const textSectionTitleHeight = 26;
-
 interface ITextSectionProps {
   textHeight: number;
   textSection: ITextSection;
 }
 export function TextSection({ textHeight, textSection }: ITextSectionProps) {
-  const height = textSectionTitleHeight + (!textSection.hidden ? textHeight : 0);
+  const { hidden, text, title } = textSection;
+  const height = textSectionTitleHeight + (!hidden ? textHeight : 0);
   return (
     <div className="text-section" style={{ height }}>
       <div className="text-section-title" style={{ height: textSectionTitleHeight }}>
-        <TextSectionTitle count={textSection.text.length} title={textSection.title} />
-        <button onClick={() => textStore.toggleTextSectionVisibility(textSection)}>X</button>
+        <TextSectionTitle count={text.length} title={title} />
+        <button
+          className={clsx("hide-button", { hidden })}
+          onClick={() => textStore.toggleTextSectionVisibility(textSection)}
+        >
+          <ArrowIcon />
+        </button>
       </div>
-      {!textSection.hidden && (
+      {!hidden && (
         <div className="text-section-text" style={{ height: textHeight }}>
-          {textSection.text.map(text => {
+          {text.map(text => {
             const indexString = text.index != null ? `${text.index + 1}. ` : "";
             return (
               <div className="phrase-row" key={indexString}>

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -368,3 +368,12 @@ export async function scrollCaseTableToRight(iDataContextName: string): Promise<
 	return false;
 }
 
+export async function updatePluginDimensions(width: number, height: number) {
+	codapInterface.sendRequest({
+		action: 'update',
+		resource: 'interactiveFrame',
+		values: {
+			dimensions: { width, height }
+		}
+	});
+}

--- a/src/stores/store_types_and_constants.ts
+++ b/src/stores/store_types_and_constants.ts
@@ -323,6 +323,7 @@ export interface ITextSectionText {
 	textParts: ITextPart[];
 }
 export interface ITextSection {
-	title?: ITextSectionTitle;
+	hidden?: boolean;
 	text: ITextSectionText[];
+	title?: ITextSectionTitle;
 }

--- a/src/stores/text_store.ts
+++ b/src/stores/text_store.ts
@@ -47,6 +47,14 @@ export class TextStore {
 		this.textSections = sections;
 	}
 
+	getTextSectionId(textSection: ITextSection) {
+		return `section-${textSection.title?.actual}-${textSection.title?.predicted}`;
+	}
+
+	toggleTextSectionVisibility(textSection: ITextSection) {
+		textSection.hidden = !textSection.hidden;
+	}
+
 	/**
 	 * Only add a text component if one with the designated name does not already exist.
 	 */

--- a/src/stores/ui_store.ts
+++ b/src/stores/ui_store.ts
@@ -9,11 +9,15 @@ const tTitles = ['Target', 'Features', 'Training', 'Testing'];
 export interface IUiStoreJSON {
 	tabPanelSelectedIndex: number;
 	trainingPanelShowsEditor: boolean;
+	showStoryQPanel?: boolean;
+	showTextPanel?: boolean;
 }
 
 export class UiStore {
-	tabPanelSelectedIndex: number = 0;
-	trainingPanelShowsEditor: boolean = false;
+	tabPanelSelectedIndex = 0;
+	trainingPanelShowsEditor = false;
+	showStoryQPanel = true;
+	showTextPanel = true;
 
 	constructor() {
 		makeAutoObservable(this);
@@ -31,6 +35,8 @@ export class UiStore {
 		if (json) {
 			this.tabPanelSelectedIndex = json.tabPanelSelectedIndex ?? 0;
 			this.trainingPanelShowsEditor = json.trainingPanelShowsEditor ?? false;
+			this.showStoryQPanel = json.showStoryQPanel ?? true;
+			this.showTextPanel = json.showTextPanel ?? true;
 		}
 	}
 
@@ -40,6 +46,14 @@ export class UiStore {
 
 	setTrainingPanelShowsEditor(value: boolean) {
 		this.trainingPanelShowsEditor = value;
+	}
+
+	setShowStoryQPanel(value: boolean) {
+		this.showStoryQPanel = value;
+	}
+
+	setShowTextPanel(value: boolean) {
+		this.showTextPanel = value;
 	}
 }
 

--- a/src/storyq.test.tsx
+++ b/src/storyq.test.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import Storyq from './components/storyq';
-
-it('renders without crashing', async () => {
-  render(<Storyq />)
-  expect(screen.getByText("Welcome to StoryQ!")).toBeInTheDocument()
-});


### PR DESCRIPTION
Jira Story: https://concord-consortium.atlassian.net/browse/STORYQ-11

This PR adds a few features to the new text pane. These features have not been finalized or designed yet, so I did my best to make them look decent without spending too much time on appearances. Hopefully this will give the project and design teams an opportunity to try the features to have a better idea of how they could work as they work on final designs.
- Collapse buttons have been added for the main and text panes. These look a bit like CLUE's. Only one of the two panes can be collapsed at any given time.
  - A cypress test has been added to test this functionality.
- Text sections in the text pane can now be hidden. Visible text sections will use the space freed up by hidden sections.
- Text section titles now include a count of the cases that exist in that section.

I also removed `storyq.test.tsx`. This test stopped working when I started importing an svg to use in the collapse pane and hide section buttons. The test just checks to make sure the main pane renders, which is already handled by the `workspace.test.ts` cypress test, so we're not losing any coverage by removing it.