### PR TITLE
Storyq-12 More Highlighting

### DIFF
--- a/src/stores/feature_store.ts
+++ b/src/stores/feature_store.ts
@@ -10,7 +10,7 @@ import {
 	GetItemSearchResponse
 } from '../types/codap-api-types';
 import {
-	Feature, FeatureType, getStarterFeature, kFeatureKindColumn, kFeatureKindNgram, kFeatureKindSearch,
+	Feature, FeatureType, getStarterFeature, kAnyNumberKeyword, kFeatureKindColumn, kFeatureKindNgram, kFeatureKindSearch,
 	kFeatureTypeConstructed, kFeatureTypeUnigram, kTokenTypeUnigram, kWhatOptionNumber, kWhatOptionText, NgramDetails,
 	SearchDetails, TokenMap, WordListSpec
 } from "./store_types_and_constants";
@@ -134,7 +134,7 @@ export class FeatureStore {
 				tSecondPart = tDetails.freeFormText !== '' ? `"${tDetails.freeFormText.trim()}"` :
 					tDetails.punctuation !== '' ? tDetails.punctuation :
 					tDetails.wordList && tDetails.wordList.datasetName !== '' ? tDetails.wordList.datasetName :
-					tDetails.what === kWhatOptionNumber ? 'anyNumber' : '';
+					tDetails.what === kWhatOptionNumber ? kAnyNumberKeyword : '';
 			return `${tFirstPart}: ${tSecondPart}`;
 		} else if (iFeature.info.kind === kFeatureKindNgram) {
 			const ignoringPart = iFeature.info.ignoreStopWords ? 'ignoring stopwords' : '';
@@ -155,7 +155,8 @@ export class FeatureStore {
 					` of ${tDetails.wordList.datasetName}` : '';
 			return `${tFirstPart} ${tSecondPart}${tThirdPart}`
 		} else if (iFeature.info.kind === kFeatureKindNgram) {
-			return `${(iFeature.info.details as NgramDetails).n}gram with frequency threshold of ${iFeature.info.frequencyThreshold},
+			const n = (iFeature.info.details as NgramDetails).n;
+			return `${n}gram with frequency threshold of ${iFeature.info.frequencyThreshold},
 			${iFeature.info.ignoreStopWords ? '' : ' not'} ignoring stop words`;
 		} else {
 			return '';

--- a/src/stores/store_types_and_constants.ts
+++ b/src/stores/store_types_and_constants.ts
@@ -16,6 +16,10 @@ export const kEmptyEntityInfo = {name: '', title: '', id: 0},
 		}
 	}
 
+export const kAnyNumberKeyword = "anyNumber";
+export const kNumberPattern = `[0-9]+`;
+export const kNumberRegExp = new RegExp(kNumberPattern);
+
 export const kContainOptionContain = "contain";
 export const kContainOptionNotContain = "not contain";
 export const kContainOptionStartWith = "start with";

--- a/src/stores/target_store.ts
+++ b/src/stores/target_store.ts
@@ -14,8 +14,8 @@ import { featureStore } from './feature_store';
 import { targetDatasetStore } from './target_dataset_store';
 import {
 	Feature, getContainFormula, getTargetCaseFormula,  kEmptyEntityInfo, kFeatureKindColumn, kFeatureKindNgram,
-	kSearchWhereEndWith, kSearchWhereStartWith, kWhatOptionList, kWhatOptionNumber, kWhatOptionPunctuation,
-	kWhatOptionText, SearchDetails
+	kNumberPattern, kSearchWhereEndWith, kSearchWhereStartWith, kWhatOptionList, kWhatOptionNumber,
+	kWhatOptionPunctuation, kWhatOptionText, SearchDetails
 } from "./store_types_and_constants";
 import { CreateAttributeResponse } from '../types/codap-api-types';
 
@@ -310,7 +310,6 @@ export class TargetStore {
 		}
 
 		function anyNumberFormula() {
-			const kNumberPattern = `[0-9]+`;
 			const option = (iNewFeature.info.details as SearchDetails).where;
 			return getContainFormula(option, `${tTargetAttr}, "${kNumberPattern}"`);
 		}

--- a/src/utilities/utilities.test.ts
+++ b/src/utilities/utilities.test.ts
@@ -1,3 +1,4 @@
+import { kAnyNumberKeyword } from "../stores/store_types_and_constants";
 import { highlightFeatures } from "./utilities";
 
 describe("highlightFeatures", () => {
@@ -61,6 +62,26 @@ describe("highlightFeatures", () => {
     expect(result).toEqual([
       { text: "Test", classNames: ["highlighted"] },
       { text: " text." }
+    ]);
+  });
+
+  it("should handle a punctuation feature", async () => {
+    const text = `Test text.`;
+    const selectedFeatures = ["count: ."];
+    const result = await highlightFeatures(text, selectedFeatures);
+    expect(result).toEqual([
+      { text: "Test text" },
+      { text: ".", classNames: ["highlighted"] }
+    ]);
+  });
+
+  it("should handle numbers", async () => {
+    const text = `123 abc`;
+    const selectedFeatures = [`contain: ${kAnyNumberKeyword}`];
+    const result = await highlightFeatures(text, selectedFeatures);
+    expect(result).toEqual([
+      { text: "123", classNames: ["highlighted"] },
+      { text: " abc" }
     ]);
   });
 

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -87,7 +87,7 @@ export async function highlightFeatures(text: string, selectedFeatures: (string 
 			// Strip out the word from strings like 'contain: "word"' and 'count: "word"'
 			const _containWord = selectedWord.match(/contain: "([^"]+)"/);
 			const _countWord = selectedWord.match(/count: "([^"]+)"/);
-			const singleWord = _containWord ? _containWord[1]
+			let singleWord = _containWord ? _containWord[1]
 				: _countWord ? _countWord[1]
 				: selectedWord;
 
@@ -97,6 +97,12 @@ export async function highlightFeatures(text: string, selectedFeatures: (string 
 			const list =
 				(containList && (SQ.lists[containList[1]] ?? await featureStore.getWordListFromDatasetName(containList[1])))
 				|| (countList && (SQ.lists[countList[1]] ?? await featureStore.getWordListFromDatasetName(countList[1])));
+			if (!list && (containList || countList)) {
+				// If we found a match without quotes but didn't find a list, just use the word or phrase.
+				singleWord = containList ? containList[1]
+					: countList ? countList[1]
+					: singleWord;
+			}
 			const finalList = list || [singleWord];
 
 			// Add all relevant words and phrases


### PR DESCRIPTION
Jira Story: https://concord-consortium.atlassian.net/browse/STORYQ-12

This PR expands highlighting in StoryQ to include numbers and punctuation. Both cases are covered by a jest test. Both of these cases are similar to general text, but don't include quotes in the name (`contain: "word"` vs `contain: !` or `contain: anyNumber`). This is also the pattern followed by lists. So now, if a list isn't found, we check to determine if we're looking for the `anyNumber` keyword, and if we're not we just treat the match as text.

Note that the number regexp is very naive, not including strings like `1/2` or `1.5` but including strings like `7up`. I didn't fix it in this PR, but it wouldn't be difficult to do so.