### PR TITLE
Storyq-3 Fix Not Contain

### DIFF
--- a/src/stores/store_types_and_constants.ts
+++ b/src/stores/store_types_and_constants.ts
@@ -133,12 +133,17 @@ export interface SearchDetails {
 
 type ContainsFormulaType = (args: string) => string;
 const containsFormula = (args: string) => `patternMatches(${args})>0`;
-export const containFormula: Record<SearchWhereOption, ContainsFormulaType | undefined> = {
+const notContainsFormula = (args: string) => `patternMatches(${args})=0`;
+const countFormula = (args: string) => `patternMatches(${args})`;
+export const containFormula: Record<WhereOption | SearchWhereOption, ContainsFormulaType | undefined> = {
 	[kSearchWhereContain]: containsFormula,
-	[kSearchWhereNotContain]: (args: string) => `patternMatches(${args})=0`,
+	[kSearchWhereNotContain]: notContainsFormula,
+	[kContainOptionNotContain]: notContainsFormula,
 	[kSearchWhereStartWith]: containsFormula,
+	[kContainOptionStartWith]: containsFormula,
 	[kSearchWhereEndWith]: containsFormula,
-	[kSearchWhereCount]: (args: string) => `patternMatches(${args})`,
+	[kContainOptionEndWith]: containsFormula,
+	[kSearchWhereCount]: countFormula,
 	"": undefined
 };
 export function getContainFormula(option: SearchWhereOption, args: string): string {

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -29,8 +29,8 @@ export function textToObject(iText: string, iSelectedWords: (string | number)[],
 		let tRawWord = iWord.toLowerCase();
 		const containedWords = iSelectedWords.map(selectedWord => {
 			// Strip out the word from strings like 'contain: "word"' and 'count: "word"'
-			const _containedWord = typeof selectedWord === "string" && selectedWord.match(/contain: "([^"]+)"/);
-			const _countWord = typeof selectedWord === "string" && selectedWord.match(/count: "([^"]+)"/);
+			const _containedWord = typeof selectedWord === "string" && selectedWord.match(/^contain: "([^"]+)"/);
+			const _countWord = typeof selectedWord === "string" && selectedWord.match(/^count: "([^"]+)"/);
 			const containedWord = _containedWord ? _containedWord[1]
 				: _countWord ? _countWord[1]
 				: selectedWord;
@@ -86,8 +86,8 @@ export async function highlightFeatures(text: string, selectedFeatures: (string 
 	for (const selectedWord of selectedFeatures) {
 		if (typeof selectedWord === "string") {
 			// Strip out the word from strings like 'contain: "word"' and 'count: "word"'
-			const _containWord = selectedWord.match(/contain: "([^"]+)"/);
-			const _countWord = selectedWord.match(/count: "([^"]+)"/);
+			const _containWord = selectedWord.match(/^contain: "([^"]+)"/);
+			const _countWord = selectedWord.match(/^count: "([^"]+)"/);
 			let singleWord = _containWord ? _containWord[1]
 				: _countWord ? _countWord[1]
 				: selectedWord;


### PR DESCRIPTION
Jira Story: https://concord-consortium.atlassian.net/browse/STORYQ-3

This PR fixes a bug which caused the "not contain" feature to work in the same way as "contain".
- The main problem, which probably was introduced during the major refactor, was caused by keying a dictionary with a `WhereOption` instead of a `SearchWhereOption`. The solution is to include both types as keys in the dictionary.
- A secondary problem was matching `contain: word` without ensuring it was the start of the string, which would also match `not contain: word`.

Note: I started working on this branch thinking it would be for another story, but quickly realized the bug described in STORYQ-3 could be reproduced so switched to fixing it.