### PR TITLE
Storyq-28 Text Display Bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "storyq",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "storyq",
-      "version": "2.18.0",
+      "version": "2.18.1",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-solid-svg-icons": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storyq",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "homepage": ".",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.6.0",

--- a/src/components/text-pane/text-section.tsx
+++ b/src/components/text-pane/text-section.tsx
@@ -16,18 +16,18 @@ interface ITextSectionTitleProps {
 function TextSectionTitle({ count, title }: ITextSectionTitleProps) {
   if (!title) return null;
 
-  const { actual, predicted, color } = title;
+  const { actual, actualColor, predicted, predictedColor } = title;
   return (
     <span className="actual-title">
       {actual && (
         <>
-          <span>True label: </span><span className="label" style={{ color }}>{actual}</span>
+          <span>True label: </span><span className="label" style={{ color: actualColor }}>{actual}</span>
           {predicted && <span>,&nbsp;</span>}
         </>
       )}
       {predicted && (
         <>
-          <span>Predicted label: </span><span className="label" style={{ color }}>{predicted}</span>
+          <span>Predicted label: </span><span className="label" style={{ color: predictedColor }}>{predicted}</span>
         </>
       )}
       <span>&nbsp;</span>

--- a/src/components/training_pane.scss
+++ b/src/components/training_pane.scss
@@ -6,3 +6,10 @@
   font-size: smaller;
   text-align: left;
 }
+
+.ui-button-disabled {
+  .ui-button-content {
+    color: #999;
+    cursor: default;
+  }
+}

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -9,18 +9,6 @@ export interface entityInfo {
 	numAttributes?: number
 }
 
-/**
- * Cases retrieved from dataset have this form
- */
-export interface Case {
-	id: number,
-	parent?: number,
-	children?: number[],
-	values: {
-		[index: string]: string
-	}
-}
-
 export function initializePlugin(pluginName: string, version: string, dimensions: { width: number, height: number },
 																 iRestoreStateHandler: (arg0: any) => void) {
 	const interfaceConfig = {
@@ -202,7 +190,7 @@ export async function getAttributeNames(iDatasetName: string, iCollectionName: s
  */
 export async function getCaseValues(
 	iDatasetName: string, iCollectionName: string, searchFormula?: string
-): Promise<Case[]> {
+): Promise<CaseInfo[]> {
 	const formula = searchFormula ?? `true`;
 	const tResult: any = await codapInterface.sendRequest({
 		action: 'get',

--- a/src/managers/headings_manager.tsx
+++ b/src/managers/headings_manager.tsx
@@ -44,14 +44,26 @@ export class HeadingsManager {
 	get headings(): Record<string, ITextSectionTitle> {
 		const { positiveClassName, negativeClassName } = targetStore;
 		return {
-			negNeg: { actual: negativeClassName, predicted: negativeClassName, color: this.colors.green },
-			negPos: { actual: negativeClassName, predicted: positiveClassName, color: this.colors.red },
-			negBlank: { actual: negativeClassName, color: this.colors.negativeBlue },
-			posNeg: { actual: positiveClassName, predicted: negativeClassName, color: this.colors.red },
-			posPos: { actual: positiveClassName, predicted: positiveClassName, color: this.colors.green },
-			posBlank: { actual: positiveClassName, color: this.colors.positiveOrange },
-			blankNeg: { predicted: negativeClassName, color: this.colors.orange },
-			blankPos: { predicted: positiveClassName, color: this.colors.blue }
+			negNeg: {
+				actual: negativeClassName, actualColor: this.colors.negativeBlue,
+				predicted: negativeClassName, predictedColor: this.colors.negativeBlue
+			},
+			negPos: {
+				actual: negativeClassName, actualColor: this.colors.negativeBlue,
+				predicted: positiveClassName, predictedColor: this.colors.positiveOrange
+			},
+			negBlank: { actual: negativeClassName, actualColor: this.colors.negativeBlue },
+			posNeg: {
+				actual: positiveClassName, actualColor: this.colors.positiveOrange,
+				predicted: negativeClassName, predictedColor: this.colors.negativeBlue
+			},
+			posPos: {
+				actual: positiveClassName, actualColor: this.colors.positiveOrange,
+				predicted: positiveClassName, predictedColor: this.colors.positiveOrange
+			},
+			posBlank: { actual: positiveClassName, actualColor: this.colors.positiveOrange },
+			blankNeg: { predicted: negativeClassName, predictedColor: this.colors.negativeBlue },
+			blankPos: { predicted: positiveClassName, predictedColor: this.colors.positiveOrange }
 		};
 	}
 }

--- a/src/managers/headings_manager.tsx
+++ b/src/managers/headings_manager.tsx
@@ -44,7 +44,7 @@ export class HeadingsManager {
 	get headings(): Record<string, ITextSectionTitle> {
 		const { positiveClassName, negativeClassName } = targetStore;
 		return {
-			negNeg: { actual: negativeClassName, predicted: positiveClassName, color: this.colors.green },
+			negNeg: { actual: negativeClassName, predicted: negativeClassName, color: this.colors.green },
 			negPos: { actual: negativeClassName, predicted: positiveClassName, color: this.colors.red },
 			negBlank: { actual: negativeClassName, color: this.colors.negativeBlue },
 			posNeg: { actual: positiveClassName, predicted: negativeClassName, color: this.colors.red },

--- a/src/managers/model_manager.ts
+++ b/src/managers/model_manager.ts
@@ -361,7 +361,9 @@ export class ModelManager {
 					}
 					if (tValue) tColumnFeatures[aName] = tValue;
 				});
-				tDocuments.push({ example: tText, class: tClass, caseID: tCaseID, columnFeatures: tColumnFeatures });
+				tDocuments.push({
+					example: String(tText), class: String(tClass), caseID: tCaseID, columnFeatures: tColumnFeatures
+				});
 			});
 		}
 

--- a/src/managers/notification_manager.ts
+++ b/src/managers/notification_manager.ts
@@ -78,8 +78,8 @@ export class NotificationManager {
 			if (tUpdatedCases.length > 0) {
 				action(() => {
 					tUpdatedCases.forEach(iCase => {
-						const tChosen = iCase.values.chosen === 'true';
-						const highlight = iCase.values.highlight === "true";
+						const tChosen = iCase.values.chosen === 'true' || iCase.values.chosen === true;
+						const highlight = iCase.values.highlight === "true" || iCase.values.highlight === true;
 						const tType = iCase.values.type;
 						const tName = String(iCase.values.name);
 						const tFoundFeature = tType !== kTokenTypeUnigram && features.find(iFeature => iFeature.name === tName);

--- a/src/managers/testing_manager.ts
+++ b/src/managers/testing_manager.ts
@@ -106,7 +106,7 @@ export class TestingManager {
 			tPhraseCount = tTestCases.length;
 			tTestCases.forEach(iCase => {
 				let tPhraseID = iCase.id,
-					tPhrase = iCase.values[testingStore.testingAttributeName],
+					tPhrase = String(iCase.values[testingStore.testingAttributeName]),
 					tActual = tClassAttributeName === this_.kNonePresent ? '' :
 						iCase.values[tClassAttributeName],
 					tGiven = Array(tTokens.length).fill(0),
@@ -128,7 +128,7 @@ export class TestingManager {
 				tTokens.forEach((iToken, iIndex) => {
 					if (iToken.formula !== '') {
 						// Codap v3 currently returns strings, even for booleans, so we have to compare the string for now
-						if (iCase.values[iToken.name] === "true") {
+						if (iCase.values[iToken.name] === "true" || iCase.values[iToken.name] === true) {
 							// Mark it in the array
 							tGiven[iIndex] = 1;
 							// Add the case ID to the list of featureIDs for this phrase

--- a/src/managers/testing_manager.ts
+++ b/src/managers/testing_manager.ts
@@ -71,33 +71,31 @@ export class TestingManager {
 				const tLabelExists =
 					await attributeExists(tTestingDatasetName, tTestingCollectionName, tTargetPredictedLabelAttributeName);
 				if (!tLabelExists) {
-					tAttributeRequests.push(
-						{
-							name: tTargetPredictedLabelAttributeName,
-							description: 'The label predicted by the model'
-						})
-					tAttributeRequests.push(
-						{
-							name: tTargetPredictedProbabilityName,
-							description: 'The probability predicted by the model that the classification is positive',
-							unit: '%',
-							precision: 3
-						})
+					tAttributeRequests.push({
+						name: tTargetPredictedLabelAttributeName,
+						description: 'The label predicted by the model'
+					});
+					tAttributeRequests.push({
+						name: tTargetPredictedProbabilityName,
+						description: 'The probability predicted by the model that the classification is positive',
+						unit: '%',
+						precision: 3
+					});
 				}
 				const tFeatureIDsAttributeExists =
 					await attributeExists(tTestingDatasetName, tTestingCollectionName, targetStore.targetFeatureIDsAttributeName);
-				if (!tFeatureIDsAttributeExists)
-					tAttributeRequests.push(
-						{
-							name: targetStore.targetFeatureIDsAttributeName,
-							hidden: true
-						})
+				if (!tFeatureIDsAttributeExists) {
+					tAttributeRequests.push({
+						name: targetStore.targetFeatureIDsAttributeName,
+						hidden: true
+					});
+				}
 
 				await codapInterface.sendRequest({
 					action: 'create',
 					resource: `dataContext[${tTestingDatasetName}].collection[${tTestingCollectionName}].attribute`,
 					values: tAttributeRequests
-				})
+				});
 			}
 		}
 
@@ -105,7 +103,7 @@ export class TestingManager {
 			if (!tStoredModel || !tPredictor) return;
 
 			const tTestCases = await getCaseValues(tTestingDatasetName, tTestingCollectionName);
-			tPhraseCount = tTestCases.length
+			tPhraseCount = tTestCases.length;
 			tTestCases.forEach(iCase => {
 				let tPhraseID = iCase.id,
 					tPhrase = iCase.values[testingStore.testingAttributeName],
@@ -129,7 +127,8 @@ export class TestingManager {
 				// The column features are names of attributes we expect to find having values true or false
 				tTokens.forEach((iToken, iIndex) => {
 					if (iToken.formula !== '') {
-						if (iCase.values[iToken.name]) {
+						// Codap v3 currently returns strings, even for booleans, so we have to compare the string for now
+						if (iCase.values[iToken.name] === "true") {
 							// Mark it in the array
 							tGiven[iIndex] = 1;
 							// Add the case ID to the list of featureIDs for this phrase

--- a/src/managers/text_feedback_manager.ts
+++ b/src/managers/text_feedback_manager.ts
@@ -177,9 +177,9 @@ export class TextFeedbackManager {
 			})
 		) as GetCaseByIDResponse[];
 
-		function addToFeatureMap(value: string, id: number, childID?: number) {
+		function addToFeatureMap(value: string, id: number, childIDs?: number[]) {
 			tFeaturesMap[id] = value;
-			if (childID) tFeaturesMap[childID] = value;
+			if (childIDs) childIDs.forEach(childID => tFeaturesMap[childID] = value);
 		}
 		const tUsedIDsSet: Set<number> = new Set();
 		// If we're using the testing dataset, we go through each of the target phrases and pull out the case IDs
@@ -216,7 +216,7 @@ export class TextFeedbackManager {
 							});
 						}
 						const aCase = iResult.values.case;
-						addToFeatureMap(String(aCase.values.name), aCase.id, aCase.children[0]);
+						addToFeatureMap(String(aCase.values.name), aCase.id, aCase.children);
 					}
 				}
 			});
@@ -311,10 +311,12 @@ export class TextFeedbackManager {
 				// Get the features and stash them in a set
 				const tSelectedFeatureCases = await getSelectedCasesFrom(datasetName, collectionName);
 				tSelectedFeatureCases.forEach(iCase => {
-					// This used to use the caseId, but the featureIDs saved in the training cases are ids for the children.
-					// I'm using child case ids here now, but it's possible they should both use case ids instead.
-					const childCaseId = iCase.children[0];
-					if (childCaseId) tFeaturesMap[Number(childCaseId)] = String(iCase.values.name);
+					// It would be better if this were just the caseId, but child ids are used throughout the StoryQ codebase,
+					// so it's better to just include all ids in this dictionary.
+					tFeaturesMap[iCase.id] = String(iCase.values.name);
+					iCase.children.forEach(childCaseId => {
+						if (childCaseId) tFeaturesMap[Number(childCaseId)] = String(iCase.values.name);
+					});
 				});
 			}
 		}

--- a/src/managers/text_feedback_manager.ts
+++ b/src/managers/text_feedback_manager.ts
@@ -195,9 +195,10 @@ export class TextFeedbackManager {
 						featureIDsJSON.forEach(anID => {
 							if (typeof anID === "number" && (tIDsOfFeaturesToSelect.includes(anID) || weightParents[anID])) {
 								tUsedIDsSet.add(iCase.id);
+								const feature = featureStore.getFeatureOrTokenByCaseId(anID);
+								const token = "name" in feature ? feature.name : "token" in feature ? feature.token : undefined;
+								if (token) addToFeatureMap(String(token), anID);
 							}
-							const feature = featureStore.getFeatureByCaseId(anID);
-							if (feature) addToFeatureMap(String(feature.name), anID);
 						});
 					}
 				}

--- a/src/managers/text_feedback_manager.ts
+++ b/src/managers/text_feedback_manager.ts
@@ -129,32 +129,20 @@ export class TextFeedbackManager {
 				collectionName, datasetName
 			} = this.getBasicInfo(),
 			tFeaturesMap: Record<number, string> = {},
-			tSelectedFeaturesSet: Set<number> = new Set(),
-			tUsedIDsSet: Set<number> = new Set(),
-			// Get all the selected cases in the Features dataset. Some will be features and some will be weights
-			tSelectionListResult = await codapInterface.sendRequest({
-				action: 'get',
-				resource: `dataContext[${datasetName}].selectionList`
-			}) as GetSelectionListResponse,
 			tCaseRequests: APIRequest[] = [];
 
-		async function handleSelectionInFeaturesDataset() {
-			if (tIDsOfFeaturesToSelect.length > 0) {
-				// Select the features
-				await codapInterface.sendRequest({
-					action: 'create',
-					resource: `dataContext[${datasetName}].selectionList`,
-					values: tIDsOfFeaturesToSelect
-				});
-			}
-		}
 
 		// If we have a testing dataset but no test has been run, we're done
-		if (useTestingDataset && testingStore.testingResultsArray.length === 0) {
-			return;
-		}
+		if (useTestingDataset && testingStore.testingResultsArray.length === 0) return;
 
+		// Get all the selected cases in the Features dataset. Some will be features and some will be weights
 		// For the features, we just need to record their caseIDs. For the weights, we record a request to get parents
+		const tSelectedFeaturesSet: Set<number> = new Set();
+		const weightParents: Record<number, number> = {};
+		const tSelectionListResult = await codapInterface.sendRequest({
+			action: 'get',
+			resource: `dataContext[${datasetName}].selectionList`
+		}) as GetSelectionListResponse;
 		if (tSelectionListResult.success && tSelectionListResult.values) {
 			tSelectionListResult.values.forEach(iValue => {
 				if (iValue.collectionName === collectionName) {
@@ -165,7 +153,7 @@ export class TextFeedbackManager {
 						resource: `dataContext[${datasetName}].collection[${iValue.collectionName}].caseByID[${iValue.caseID}]`
 					});
 				}
-			})
+			});
 		}
 		// Get the parents
 		if (tCaseRequests.length > 0) {
@@ -173,10 +161,12 @@ export class TextFeedbackManager {
 			tCaseResults.forEach(iResult => {
 				if (iResult.success && iResult.values?.case.parent) {
 					tSelectedFeaturesSet.add(iResult.values.case.parent);
+					weightParents[iResult.values.case.id] = iResult.values.case.parent;
 				}
 			})
 		}
-		const tIDsOfFeaturesToSelect = Array.from(tSelectedFeaturesSet)
+		const tIDsOfFeaturesToSelect = Array.from(tSelectedFeaturesSet);
+
 		// We need all the features as cases so we can get their used caseIDs from the target dataset
 		const tFeatureCasesResult = await codapInterface.sendRequest(
 			tIDsOfFeaturesToSelect.map(iID => {
@@ -186,20 +176,28 @@ export class TextFeedbackManager {
 				};
 			})
 		) as GetCaseByIDResponse[];
+
+		function addToFeatureMap(value: string, id: number, childID?: number) {
+			tFeaturesMap[id] = value;
+			if (childID) tFeaturesMap[childID] = value;
+		}
+		const tUsedIDsSet: Set<number> = new Set();
 		// If we're using the testing dataset, we go through each of the target phrases and pull out the case IDs
 		// of the cases that use the selected features. We determine this by looking at the featureIDs attribute
 		// of each target phrase case and checking whether that array contains any of the selected feature IDs.
 		if (useTestingDataset) {
 			const tTestCases = await getCaseValues(tDatasetName, tCollectionName);
 			tTestCases.forEach(iCase => {
-				const tFeatureIDs = iCase.values.featureIDs
+				const tFeatureIDs = iCase.values.featureIDs;
 				if (typeof tFeatureIDs === 'string' && tFeatureIDs.length > 0) {
 					const featureIDsJSON = JSON.parse(tFeatureIDs);
 					if (Array.isArray(featureIDsJSON)) {
 						featureIDsJSON.forEach(anID => {
-							if (typeof anID === "number" && tIDsOfFeaturesToSelect.includes(anID)) {
+							if (typeof anID === "number" && (tIDsOfFeaturesToSelect.includes(anID) || weightParents[anID])) {
 								tUsedIDsSet.add(iCase.id);
 							}
+							const feature = featureStore.getFeatureByCaseId(anID);
+							if (feature) addToFeatureMap(String(feature.name), anID);
 						});
 					}
 				}
@@ -216,15 +214,12 @@ export class TextFeedbackManager {
 								if (typeof anID === "number") tUsedIDsSet.add(anID);
 							});
 						}
-						tFeaturesMap[iResult.values.case.id] = String(iResult.values.case.values.name);
-						const childID = iResult.values.case.children[0];
-						if (childID) tFeaturesMap[childID] = String(iResult.values.case.values.name);
+						const aCase = iResult.values.case;
+						addToFeatureMap(String(aCase.values.name), aCase.id, aCase.children[0]);
 					}
 				}
 			});
 		}
-
-		await handleSelectionInFeaturesDataset();
 
 		// Select the target texts that make use of the selected features
 		const tUsedCaseIDs = Array.from(tUsedIDsSet);
@@ -233,8 +228,9 @@ export class TextFeedbackManager {
 			resource: `dataContext[${tDatasetName}].selectionList`,
 			values: tUsedCaseIDs
 		});
-		const tQuadruples: PhraseQuadruple[] = [];
+		
 		// Here is where we put the contents of the text component together
+		const tQuadruples: PhraseQuadruple[] = [];
 		for (const index in tUsedCaseIDs) {
 			const caseId = tUsedCaseIDs[index];
 			const tGetCaseResult = await codapInterface.sendRequest({
@@ -314,10 +310,10 @@ export class TextFeedbackManager {
 				// Get the features and stash them in a set
 				const tSelectedFeatureCases = await getSelectedCasesFrom(datasetName, collectionName);
 				tSelectedFeatureCases.forEach(iCase => {
-					// This used to use the caseId, but the featureIDs saved in the training cases are item ids.
-					// I'm using item ids here now, but it's possible they should both use case ids instead.
-					const itemId = iCase.children[0];
-					if (itemId) tFeaturesMap[Number(itemId)] = String(iCase.values.name);
+					// This used to use the caseId, but the featureIDs saved in the training cases are ids for the children.
+					// I'm using child case ids here now, but it's possible they should both use case ids instead.
+					const childCaseId = iCase.children[0];
+					if (childCaseId) tFeaturesMap[Number(childCaseId)] = String(iCase.values.name);
 				});
 			}
 		}

--- a/src/stores/domain_store.ts
+++ b/src/stores/domain_store.ts
@@ -569,11 +569,13 @@ export class DomainStore {
 					if (!tUsageResults[iFeatureCase.id]) tUsageResults[iFeatureCase.id] = [];
 					tUsageResults[iFeatureCase.id].push(iTargetCase.id);
 					if (!tTextResults[iTargetCase.id]) tTextResults[iTargetCase.id] = [];
+					// Would it be better to include all child case ids here?
 					if (childCaseId) tTextResults[iTargetCase.id].push(childCaseId);
 				}
 			})
 			// We need to store the featureCaseID in the token map while we've got it
 			if (featureStore.tokenMap[tFeatureName] && childCaseId) {
+				// Would it be better to include all child case ids here?
 				featureStore.updateTokenCaseId(featureStore.tokenMap[tFeatureName], childCaseId);
 			}
 		});

--- a/src/stores/domain_store.ts
+++ b/src/stores/domain_store.ts
@@ -380,7 +380,7 @@ export class DomainStore {
 			if (tCreateResult.success && tCreateResult.values) {
 				tCreateResult.values.forEach((iValue, iIndex) => {
 					// tUnigramCreateMsgs[iIndex].featureCaseID = iValue.id
-					tTokenArray[iIndex].featureCaseID = iValue.id;
+					featureStore.updateTokenCaseId(tTokenArray[iIndex], iValue.id);
 				});
 				// Put together update messages for the target cases
 				const tUpdateMsgs: UpdateCaseValue[] = [];
@@ -555,6 +555,8 @@ export class DomainStore {
 			});
 			const tFeatureName = iFeatureCase.values.name;
 			const tFeatureType = iFeatureCase.values.type;
+			// Features will only highlight with a child case id
+			const childCaseId = iFeatureCase.children?.[0];
 
 			tTargetCases.forEach(iTargetCase => {
 				const tTargetHasFeature = ['constructed', 'column'].includes(tFeatureType)
@@ -567,14 +569,12 @@ export class DomainStore {
 					if (!tUsageResults[iFeatureCase.id]) tUsageResults[iFeatureCase.id] = [];
 					tUsageResults[iFeatureCase.id].push(iTargetCase.id);
 					if (!tTextResults[iTargetCase.id]) tTextResults[iTargetCase.id] = [];
-					// Features will only highlight with a child case id
-					const childCaseId = iFeatureCase.children?.[0];
 					if (childCaseId) tTextResults[iTargetCase.id].push(childCaseId);
 				}
 			})
 			// We need to store the featureCaseID in the token map while we've got it
-			if (featureStore.tokenMap[tFeatureName]) {
-				featureStore.tokenMap[tFeatureName].featureCaseID = iFeatureCase.id;
+			if (featureStore.tokenMap[tFeatureName] && childCaseId) {
+				featureStore.updateTokenCaseId(featureStore.tokenMap[tFeatureName], childCaseId);
 			}
 		});
 		// Now we can update the target and feature cases
@@ -621,8 +621,8 @@ export class DomainStore {
 					return iStoredFeature.name === tTokenMapKey;
 				});
 			if (tToken && tStoredFeature) {
-				tToken.featureCaseID = Number(tStoredFeature.caseID);
-				tToken.caseIDs = tUsageResults[tToken.featureCaseID];
+				featureStore.updateTokenCaseId(tToken, Number(tStoredFeature.caseID));
+				tToken.caseIDs = tUsageResults[Number(tStoredFeature.caseID)];
 			}
 		}
 	}

--- a/src/stores/domain_store.ts
+++ b/src/stores/domain_store.ts
@@ -322,8 +322,8 @@ export class DomainStore {
 				tTargetAttributeName = targetStore.targetAttributeName,
 				tDocuments = targetStore.targetCases.map(iCase => {
 					return {
-						example: iCase.values[tTargetAttributeName],
-						class: iCase.values[targetStore.targetClassAttributeName],
+						example: String(iCase.values[tTargetAttributeName]),
+						class: String(iCase.values[targetStore.targetClassAttributeName]),
 						caseID: Number(iCase.id),
 						columnFeatures: {}
 					}
@@ -384,7 +384,7 @@ export class DomainStore {
 				const tUpdateMsgs: UpdateCaseValue[] = [];
 				targetStore.targetCases.forEach(iCase => {
 					const tTheseFeatureIDs = iCase.values.featureIDs;
-					const featureIDs: number[] = tTheseFeatureIDs ? JSON.parse(tTheseFeatureIDs) : [];
+					const featureIDs: number[] = tTheseFeatureIDs ? JSON.parse(String(tTheseFeatureIDs)) : [];
 					tTokenArray.forEach(iFeature => {
 						if (iFeature.caseIDs.indexOf(iCase.id) >= 0 && iFeature.featureCaseID != null) {
 							featureIDs.push(iFeature.featureCaseID);
@@ -551,17 +551,17 @@ export class DomainStore {
 			tFeatureItemRequests.push({
 				action:'get', resource:`dataContext[${datasetName}].itemByCaseID[${iFeatureCase.id}]`
 			});
-			const tFeatureName = iFeatureCase.values.name;
-			const tFeatureType = iFeatureCase.values.type;
+			const tFeatureName = String(iFeatureCase.values.name);
+			const tFeatureType = String(iFeatureCase.values.type);
 			// Features will only highlight with a child case id
 			const childCaseId = iFeatureCase.children?.[0];
 
 			tTargetCases.forEach(iTargetCase => {
 				const tTargetHasFeature = ['constructed', 'column'].includes(tFeatureType)
 					// Codap v3 returns strings, even for booleans, so we have to compare strings for now.
-					? iTargetCase.values[tFeatureName] === "true" ? true : false
+					? iTargetCase.values[tFeatureName] === "true" || iTargetCase.values[tFeatureName] === true ? true : false
 					: tFeatureType === 'unigram'
-					? targetTextHasUnigram(iTargetCase.values[targetAttributeName], tFeatureName)
+					? targetTextHasUnigram(String(iTargetCase.values[targetAttributeName]), tFeatureName)
 					: false;
 				if (tTargetHasFeature) {
 					if (!tUsageResults[iFeatureCase.id]) tUsageResults[iFeatureCase.id] = [];

--- a/src/stores/feature_store.ts
+++ b/src/stores/feature_store.ts
@@ -169,7 +169,8 @@ export class FeatureStore {
 	}
 
 	getFeatureByCaseId(caseId: string | number) {
-		return this.features.find(feature => feature.caseID === `${caseId}`);
+		return this.features.find(feature => feature.caseID === `${caseId}`) ??
+			this.features.find(feature => feature.childCaseID === `${caseId}`);
 	}
 
 	addToken(name: string, token: Token) {

--- a/src/stores/feature_store.ts
+++ b/src/stores/feature_store.ts
@@ -203,6 +203,10 @@ export class FeatureStore {
 			Object.values(this.tokenMap).find(iToken => iToken.featureCaseID === numberId);
 	}
 
+	getFeatureOrTokenByCaseId(caseId: string | number) {
+		return this.getFeatureByCaseId(caseId) ?? this.getTokenByCaseId(caseId);
+	}
+
 	getFormulaFor(iFeatureName: string) {
 		const tFoundObject = this.features.find(iFeature => {
 			return iFeature.name === iFeatureName && iFeature.formula !== '';

--- a/src/stores/feature_store.ts
+++ b/src/stores/feature_store.ts
@@ -186,6 +186,12 @@ export class FeatureStore {
 		}
 	}
 
+	updateTokenCaseId(token: Token, id: number) {
+		if (token.featureCaseID) delete this.caseIdTokenMap[token.featureCaseID];
+		this.caseIdTokenMap[id] = token;
+		token.featureCaseID = id;
+	}
+
 	clearTokens() {
 		this.setTokenMap({});
 		this.setCaseIdTokenMap({});

--- a/src/stores/store_types_and_constants.ts
+++ b/src/stores/store_types_and_constants.ts
@@ -205,6 +205,7 @@ export interface FeatureDetails {
 export interface Feature extends FeatureOrToken {
 	attrID: string // ID of the attribute in the target dataset corresponding to this feature
 	caseID: string // ID of the feature as a case in the feature table
+	childCaseID?: string // ID of the feature in the weights collection in the feature table
 	chosen: boolean
 	description: string
 	featureItemID: string // ID of the item in the feature table corresponding to this feature
@@ -225,6 +226,7 @@ export function getStarterFeature(): Feature {
 	return {
 		attrID: '',
 		caseID: '',
+		childCaseID: '',
 		chosen: false,
 		color: kNoColor,
 		description: '',

--- a/src/stores/store_types_and_constants.ts
+++ b/src/stores/store_types_and_constants.ts
@@ -340,8 +340,9 @@ export interface WordListSpec {
 
 export interface ITextSectionTitle {
 	actual?: string;
-	color: string;
+	actualColor?: string;
 	predicted?: string;
+	predictedColor?: string;
 }
 export interface ITextPart {
 	classNames?: string[];

--- a/src/stores/target_store.ts
+++ b/src/stores/target_store.ts
@@ -5,12 +5,12 @@
 
 import { makeAutoObservable, toJS } from 'mobx'
 import {
-	Case, entityInfo, getAttributeNames, getCaseValues, getCollectionNames, getDatasetInfoWithFilter, guaranteeAttribute,
+	entityInfo, getAttributeNames, getCaseValues, getCollectionNames, getDatasetInfoWithFilter, guaranteeAttribute,
 	scrollCaseTableToRight
 } from "../lib/codap-helper";
 import codapInterface from "../lib/CodapInterface";
 import { SQ } from "../lists/lists";
-import { CreateAttributeResponse } from '../types/codap-api-types';
+import { CaseInfo, CreateAttributeResponse } from '../types/codap-api-types';
 import { featureStore } from './feature_store';
 import { targetDatasetStore } from './target_dataset_store';
 import { testingStore } from './testing_store';
@@ -37,7 +37,7 @@ interface ITargetStore {
 	targetPredictedLabelAttributeName: string;
 	targetResultsCollectionName: string;
 	targetFeatureIDsAttributeName: string;
-	targetCases: Case[];
+	targetCases: CaseInfo[];
 	targetClassAttributeName: string;
 	targetClassAttributeValues: string[];
 	targetClassNames: Record<classColumns, string>;
@@ -58,7 +58,7 @@ export class TargetStore {
 	targetPredictedLabelAttributeName = ''
 	targetResultsCollectionName = 'results'
 	targetFeatureIDsAttributeName = 'featureIDs'
-	targetCases: Case[] = []
+	targetCases: CaseInfo[] = []
 	targetClassAttributeName: string = ''
 	targetClassAttributeValues: string[] = []
 	targetClassNames: Record<classColumns, string> = { left: "", right: "" }
@@ -102,7 +102,7 @@ export class TargetStore {
 		this.targetFeatureIDsAttributeName = name;
 	}
 
-	setTargetCases(cases: Case[]) {
+	setTargetCases(cases: CaseInfo[]) {
 		this.targetCases = cases;
 	}
 
@@ -202,7 +202,7 @@ export class TargetStore {
 		let tCollectionNames: string[] = [];
 		let tCollectionName = '';
 		let tAttrNames: string[] = [];
-		let tCaseValues: Case[] = [];
+		let tCaseValues: CaseInfo[] = [];
 		let tPositiveClassName = '';
 		let tNegativeClassName = '';
 		let tClassNames = { left: '', right: '' };
@@ -220,16 +220,16 @@ export class TargetStore {
 			// choose class names
 			const tTargetClassAttributeName = targetClassAttributeName ?? this.targetClassAttributeName;
 			if (tTargetClassAttributeName !== '' && tCaseValues.length > 0) {
-				tPositiveClassName = tCaseValues[0].values[tTargetClassAttributeName];
+				tPositiveClassName = String(tCaseValues[0].values[tTargetClassAttributeName]);
 				const tNegativeClassCase =
 					tCaseValues.find(iCase => iCase.values[tTargetClassAttributeName] !== tPositiveClassName);
-				tNegativeClassName = tNegativeClassCase ? tNegativeClassCase.values[tTargetClassAttributeName] : '';
+				tNegativeClassName = tNegativeClassCase ? String(tNegativeClassCase.values[tTargetClassAttributeName]) : '';
 				tClassNames = { left: tPositiveClassName, right: tNegativeClassName };
 
 				// Also make a set of the unique values of the class attribute
 				const tClassAttributeValuesSet: Set<string> = new Set();
 				tCaseValues.forEach(iCase => {
-					tClassAttributeValuesSet.add(iCase.values[tTargetClassAttributeName]);
+					tClassAttributeValuesSet.add(String(iCase.values[tTargetClassAttributeName]));
 				})
 				tClassAttributeValues = Array.from(tClassAttributeValuesSet);
 			}

--- a/src/stores/text_store.test.ts
+++ b/src/stores/text_store.test.ts
@@ -27,7 +27,7 @@ describe("textStore", () => {
 
   it("setTextSections", () => {
     const sections: ITextSection[] = [{
-      title: { actual: "Section 1", predicted: "Section 1", color: "#000" },
+      title: { actual: "Section 1", predicted: "Section 1" },
       text: [{ textParts: [{ text: "Test" }], index: 0 }],
       hidden: false
     }];
@@ -37,7 +37,7 @@ describe("textStore", () => {
 
   it("getTextSectionId", () => {
     const section: ITextSection = {
-      title: { actual: "Section 1", predicted: "Section 1", color: "#000" },
+      title: { actual: "Section 1", predicted: "Section 1" },
       text: [{ textParts: [{ text: "Test" }], index: 0 }],
       hidden: false
     };
@@ -47,7 +47,7 @@ describe("textStore", () => {
 
   it("toggleTextSectionVisibility", () => {
     const section: ITextSection = {
-      title: { actual: "Section 1", predicted: "Section 1", color: "#000" },
+      title: { actual: "Section 1", predicted: "Section 1" },
       text: [{ textParts: [{ text: "Test" }], index: 0 }],
       hidden: false
     };
@@ -74,7 +74,7 @@ describe("textStore", () => {
 
   it("clearText", async () => {
     const sections: ITextSection[] = [{
-      title: { actual: "Section 1", predicted: "Section 1", color: "#000" },
+      title: { actual: "Section 1", predicted: "Section 1" },
       text: [{ textParts: [{ text: "Test" }], index: 0 }],
       hidden: false
     }];

--- a/src/types/codap-api-types.ts
+++ b/src/types/codap-api-types.ts
@@ -93,6 +93,7 @@ export interface GetAttributeListResponse {
 
 export interface BasicCaseInfo {
   id: number
+  itemID: number
 }
 export interface CreateCaseResponse {
   success: boolean


### PR DESCRIPTION
Jira stories:
https://concord-consortium.atlassian.net/browse/STORYQ-28
https://concord-consortium.atlassian.net/browse/STORYQ-21
https://concord-consortium.atlassian.net/browse/STORYQ-22

This PR addresses several bugs related to text being displayed and highlighted properly at various stages of the StoryQ process. Text should now be displayed and highlighted properly in almost all cases:
- With regular as well as token (single word) features.
- At all stages in the process (after creating features, after training a model, and after testing a model).
- When cases are selected in the feature or text tables.

I ran out of time before I could fix text display when multiple models have been trained and the user is in the test panel. And there are probably other edge cases that still don't work properly.

There are a couple of general bugs that were causing text to display incorrectly before.
- Codap v3 returns strings for all case values, even booleans. To accommodate for this, there are a couple of places where we're explicitly looking for the string "true" in StoryQ now. Ultimately, it would be better for Codap v3 to return different types of values, but I wasn't ready to make that change, which could cause problems for other plugins. When Codap is fixed, it will probably break StoryQ here. I left comments in the code to hopefully make fixing that problem easier.
- Features are stored in a table in Codap, but each feature has at least two cases in two different collections, and possibly more. You'd think that the parent case would be used as the feature's actual case, but that isn't always (ever?) how it's represented in StoryQ. I'm not sure if this was an inconsistency in the original plugin, or whether a single error was introduced at some point that then permeated throughout the codebase. But in any case, there were several places where I changed the feature's case id to be for a (usually the) child case, rather than the parent. I think it would be much better to consistently use the parent case, but I'm not sure how much work it would take to make this switch, or if there's actually a good reason to use the child case.
- There are actually two kinds of features: regular features and "tokens" (created by single word features). There's a lot of ambiguity between these, with both features and tokens sometimes called features or even tokens in the codebase. For users, they seem like they're all features. They have to be handled differently in the code, and there were times where the code just didn't handle tokens at all. I tried to improve this situation, being more explicit about features vs tokens and handling both of them whenever it was needed, but there are still probably places where it could be improved and it will almost certainly cause confusion for future engineers.

Additional minor improvements:
- Train and step buttons in the training panel now appear disabled when they are disabled.
- Colors in text section titles are improved. This does not match the design spec, but it's an improvement over what they were previously (like neon green, very difficult to read) and I doubt I'll have time to actually address this fully.
- As usual, I made layouts more consistent and simplified code whenever possible.