### PR TITLE
Storyq-21 Token Colors

### DIFF
--- a/src/managers/text_feedback_manager.ts
+++ b/src/managers/text_feedback_manager.ts
@@ -196,8 +196,10 @@ export class TextFeedbackManager {
               if (typeof anID === "number" && (tIDsOfFeaturesToSelect.includes(anID) || weightParents[anID])) {
                 tUsedIDsSet.add(iCase.id);
                 const feature = featureStore.getFeatureOrTokenByCaseId(anID);
-                const token = "name" in feature ? feature.name : "token" in feature ? feature.token : undefined;
-                if (token) addToFeatureMap(String(token), anID);
+                if (feature) {
+                  const token = "name" in feature ? feature.name : "token" in feature ? feature.token : undefined;
+                  if (token) addToFeatureMap(String(token), anID);
+                }
               }
             });
           }
@@ -458,10 +460,8 @@ export class TextFeedbackManager {
       ['negNeg', 'negPos', 'negBlank', 'posNeg', 'posPos', 'posBlank', 'blankNeg', 'blankPos', 'blankBlank'];
     const texts: Record<string, ITextSectionText[]> = {};
 
-
-    async function addOnePhrase(iQuadruple: PhraseQuadruple) {
-      const kLabels: ClassLabel = kHeadingsManager.classLabels;
-
+    const kLabels: ClassLabel = kHeadingsManager.classLabels;
+    for (const iQuadruple of iPhraseQuadruples) {
       let tGroup: string;
       switch (iQuadruple.actual) {
         case kLabels.negLabel:
@@ -505,10 +505,6 @@ export class TextFeedbackManager {
         textParts: await highlightFeatures(iQuadruple.phrase, iQuadruple.nonNtigramFeatures),
         index: iQuadruple.index
       });
-    }
-
-    for (const iTriple of iPhraseQuadruples) {
-      await addOnePhrase(iTriple);
     }
 
     // The phrases are all in their groups. Create the array of group objects

--- a/src/stores/domain_store.ts
+++ b/src/stores/domain_store.ts
@@ -367,7 +367,7 @@ export class DomainStore {
         tCaseValues.values[tPositiveAttrName] = iFeature.numPositive;
         tCaseValues.values[tNegativeAttrName] = iFeature.numNegative;
         tUnigramCreateMsgs.push(tCaseValues);
-      })
+      });
       const tCreateResult = await codapInterface.sendRequest({
         action: 'create',
         resource: `dataContext[${datasetName}].collection[${collectionName}].case`,

--- a/src/stores/feature_store.ts
+++ b/src/stores/feature_store.ts
@@ -48,6 +48,8 @@ export class FeatureStore {
   featureWeightCaseIDs: Record<string, number> = {}
 
   constructor() {
+    // It would be better if caseIdTokenMap and tokenMap were observable. However, making tokenMap observable
+    // causes serious problems that don't seem like they'd be easy to fix.
     makeAutoObservable(
       this, { caseIdTokenMap: false, tokenMap: false, featureWeightCaseIDs: false }, { autoBind: true }
     );

--- a/src/stores/feature_store.ts
+++ b/src/stores/feature_store.ts
@@ -48,7 +48,9 @@ export class FeatureStore {
   featureWeightCaseIDs: Record<string, number> = {}
 
   constructor() {
-    makeAutoObservable(this, { tokenMap: false, featureWeightCaseIDs: false }, { autoBind: true });
+    makeAutoObservable(
+      this, { caseIdTokenMap: false, tokenMap: false, featureWeightCaseIDs: false }, { autoBind: true }
+    );
   }
 
   setCaseIdTokenMap(map: Record<number, Token>) {
@@ -199,8 +201,12 @@ export class FeatureStore {
 
   getTokenByCaseId(caseId: string | number) {
     const numberId = Number(caseId);
-    return this.caseIdTokenMap[numberId] ??
-      Object.values(this.tokenMap).find(iToken => iToken.featureCaseID === numberId);
+    const caseIdToken = this.caseIdTokenMap[numberId];
+    if (caseIdToken) return caseIdToken;
+    
+    const token = Object.values(this.tokenMap).find(iToken => iToken.featureCaseID === numberId);
+    if (token) this.caseIdTokenMap[numberId] = token;
+    return token;
   }
 
   getFeatureOrTokenByCaseId(caseId: string | number) {


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/STORYQ-21

This PR fixes a bug where colors for tokens (subfeatures created by "Single Word" features) were no longer updating properly. This was a tricky bug to fix and I learned some other relevant information on the way.

The ultimate cause for this bug is that `featureStore.tokenMap` is explicitly not observable. I hadn't noticed this previously, and it explains why toggling the visibility of a normal feature is responsive, but not for tokens.

I recently introduced `featureStore.caseIdTokenMap` to make it possible to look up tokens by id in O(1) time. (`tokenMap` keys by token, like "ice" or "great".) The problem is that `caseIdTokenMap` was observable, so even though the same token object was being assigned to both `caseIdTokenMap` and `tokenMap`, the token assigned to `caseIdTokenMap` was being converted into an observable object. This meant they were technically different objects, so changes to one were not affecting the other. This was quite a surprise to me.

The best solution to this problem would be to make `tokenMap` observable. However, doing so caused several other major problems, and after spending a bit of time digging into one without success I decided this was too big a change for now. So the solution applied in this PR is to make `caseIdTokenMap` non-observable.

There are a few other small changes, but they're mostly slight improvements to formatting and code simplification.