### PR TITLE
build: Update package.json back to 2.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "storyq",
-  "version": "2.18.1",
+  "version": "2.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "storyq",
-      "version": "2.18.1",
+      "version": "2.18.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-solid-svg-icons": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storyq",
-  "version": "2.18.1",
+  "version": "2.18.0",
   "homepage": ".",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.6.0",


### PR DESCRIPTION
It was at 2.18.1 but 2.18.0 was not released so reverting back.  The displayed app version in CODAP was already 2.18.0.