### PR TITLE
fix: Text pane stuck at a stale width in a split window [STORYQ-80]

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,8 @@ module.exports = {
   moduleNameMapper: {
     // Mock CSS imports, suggested by ChatGPT
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    // Mock svg imports, which are handled by svgr in the app but not by jest
+    '\\.svg$': '<rootDir>/src/__mocks__/svg-mock.tsx',
   },
   setupFilesAfterEnv: ['@testing-library/jest-dom'],
 };

--- a/src/__mocks__/svg-mock.tsx
+++ b/src/__mocks__/svg-mock.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+// Stands in for CRA's svgr imports, which jest cannot parse.
+export const ReactComponent = (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />;
+
+const svgMock = "svg-mock";
+export default svgMock;

--- a/src/components/collapse-button.scss
+++ b/src/components/collapse-button.scss
@@ -1,3 +1,5 @@
+@import "./constants.module.scss";
+
 .collapse-button {
   align-items: center;
   background-color: #eee;
@@ -8,7 +10,7 @@
   height: 100vh;
   justify-content: center;
   padding: 0;
-  width: 24px;
+  width: $collapse-button-width;
 
   &:hover {
     background-color: #e4e4e4;

--- a/src/components/collapse-button.tsx
+++ b/src/components/collapse-button.tsx
@@ -4,8 +4,6 @@ import { ReactComponent as ArrowIcon } from "../assets/arrow-icon.svg";
 
 import "./collapse-button.scss";
 
-export const collapseButtonWidth = 16;
-
 interface ICollapseButtonProps {
   direction: "left" | "right";
   onClick: () => void;

--- a/src/components/constants.module.scss
+++ b/src/components/constants.module.scss
@@ -1,5 +1,7 @@
+$collapse-button-width: 24px;
 $pane-divider-size: 24px;
 
 :export {
+  collapseButtonWidth: $collapse-button-width;
   paneDividerSize: $pane-divider-size
 }

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -1,4 +1,4 @@
 import constants from "./constants.module.scss";
 
-export const kCollapseButtonWidth = parseInt(constants.collapseButtonWidth);
-export const kPaneDividerSize = parseInt(constants.paneDividerSize);
+export const kCollapseButtonWidth = parseInt(constants.collapseButtonWidth, 10);
+export const kPaneDividerSize = parseInt(constants.paneDividerSize, 10);

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -1,3 +1,4 @@
 import constants from "./constants.module.scss";
 
+export const kCollapseButtonWidth = parseInt(constants.collapseButtonWidth);
 export const kPaneDividerSize = parseInt(constants.paneDividerSize);

--- a/src/components/storyq.tsx
+++ b/src/components/storyq.tsx
@@ -10,7 +10,8 @@ import { kStoryQPluginName } from "../stores/store_types_and_constants";
 import { targetStore } from '../stores/target_store';
 import { testingStore } from "../stores/testing_store";
 import { IUiStoreJSON, uiStore } from "../stores/ui_store";
-import { CollapseButton, collapseButtonWidth } from "./collapse-button";
+import { CollapseButton } from "./collapse-button";
+import { kCollapseButtonWidth } from "./constants";
 import { FeaturePanel } from "./feature_panel";
 import { TargetPanel } from "./target_panel";
 import { TestingPanel, kNonePresent } from "./testing_panel";
@@ -24,7 +25,7 @@ import './storyq.scss';
 
 const paneWidth = 430;
 function getPluginWidth() {
-  return (paneWidth + collapseButtonWidth) * (uiStore.showStoryQPanel && uiStore.showTextPanel ? 2 : 1);
+  return (paneWidth + kCollapseButtonWidth) * (uiStore.showStoryQPanel && uiStore.showTextPanel ? 2 : 1);
 }
 const pluginHeight = 420;
 
@@ -99,6 +100,9 @@ const Storyq = observer(class Storyq extends Component<IStoryqProps, {}> {
         uiStore.fromJSON(iStorage.uiStore);
         domainStore.fromJSON(iStorage.domainStore);
         await targetStore.updateFromCODAP()
+        // The restored panel visibility flags may not match the dimensions requested at startup,
+        // so re-assert the width we want now that they have settled.
+        updatePluginDimensions(getPluginWidth(), pluginHeight)
       }
     }
 

--- a/src/components/text-pane/text-pane.test.tsx
+++ b/src/components/text-pane/text-pane.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { TextPane } from "./text-pane";
+
+// jsdom does not implement ResizeObserver, so record what the component asks to observe.
+const observed: Element[] = [];
+class MockResizeObserver {
+  constructor(readonly callback: ResizeObserverCallback) {}
+  observe(target: Element) { observed.push(target); }
+  unobserve() {}
+  disconnect() {}
+}
+
+describe("TextPane", () => {
+  beforeAll(() => {
+    global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+  });
+
+  beforeEach(() => {
+    observed.length = 0;
+  });
+
+  // The pane can be resized without its parent changing size, for instance when the StoryQ panel
+  // beside it is collapsed and flex hands the freed space to the pane. Observing the parent misses
+  // that, leaving the pane rendering at a stale width (STORYQ-80).
+  it("observes its own element rather than its parent", () => {
+    const { container } = render(<TextPane />);
+    const pane = container.querySelector(".text-pane");
+
+    expect(pane).toBeInTheDocument();
+    expect(observed).toEqual([pane]);
+  });
+});

--- a/src/components/text-pane/text-pane.test.tsx
+++ b/src/components/text-pane/text-pane.test.tsx
@@ -12,8 +12,14 @@ class MockResizeObserver {
 }
 
 describe("TextPane", () => {
+  const originalResizeObserver = global.ResizeObserver;
+
   beforeAll(() => {
     global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+  });
+
+  afterAll(() => {
+    global.ResizeObserver = originalResizeObserver;
   });
 
   beforeEach(() => {

--- a/src/components/text-pane/text-pane.tsx
+++ b/src/components/text-pane/text-pane.tsx
@@ -65,11 +65,13 @@ export const TextPane = observer(function TextPane() {
     // update on window resize
     window.addEventListener('resize', updateDimensions);
 
-    // observe the parent element of the pane
+    // Observe the pane itself rather than its parent. The pane can be resized without the parent
+    // changing size, for instance when the StoryQ panel beside it is collapsed and flex hands the
+    // freed space to the pane.
     let resizeObserver: ResizeObserver | null = null;
-    if (paneRef.current?.parentElement) {
+    if (paneRef.current) {
       resizeObserver = new ResizeObserver(updateDimensions);
-      resizeObserver.observe(paneRef.current.parentElement);
+      resizeObserver.observe(paneRef.current);
     }
 
     return () => {

--- a/src/components/text-pane/text-pane.tsx
+++ b/src/components/text-pane/text-pane.tsx
@@ -65,9 +65,8 @@ export const TextPane = observer(function TextPane() {
     // update on window resize
     window.addEventListener('resize', updateDimensions);
 
-    // Observe the pane itself rather than its parent. The pane can be resized without the parent
-    // changing size, for instance when the StoryQ panel beside it is collapsed and flex hands the
-    // freed space to the pane.
+    // Observe the pane, not its parent: the pane can resize while
+    // the parent does not, e.g. when the panel beside it collapses.
     let resizeObserver: ResizeObserver | null = null;
     if (paneRef.current) {
       resizeObserver = new ResizeObserver(updateDimensions);


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/STORYQ-80

The text pane sometimes rendered at a stale, too-narrow width: a single selected review filled only part of the tile, and two selected reviews were squeezed into narrow columns. Resizing the tile or changing the zoom level cleared it up.

`TextPane` measures its own `.text-pane` element but attached its `ResizeObserver` to the parent `.storyq-container`. The pane can change width without the parent changing at all: when the StoryQ panel beside it unmounts, flex hands the freed space to the pane while the container keeps its size. None of the three triggers (the mount-time `requestAnimationFrame`, the `window` resize listener, or the parent observer) fire, so `containerWidth` stays at whatever it was while the two panels shared the tile, and that stale value is what sizes the sections. This is why it only shows up in the Activity Player + CODAP V3 chain, where the host clamps StoryQ's requested width and the restored `showStoryQPanel` flag then collapses the panel after the first render.

Observing the pane itself makes the measurement self-correcting. It is a superset of the old coverage, since the pane is `width: 100%; flex: 1 1 auto` and so also resizes whenever the container does, and it cannot feed back into itself because the pane's width is never derived from `containerWidth`.

Measured in the browser at a 446px viewport, reproducing the reported clamp: collapsing the StoryQ panel grows `.text-pane` from 194px to 422px while the parent stays at 446px. A `ResizeObserver` on the parent fires zero times across that change; one on the pane fires once.

Two smaller changes ride along:

- `collapseButtonWidth` was still 16 in TypeScript after the button's CSS grew to 24px in f08d0e2, so `getPluginWidth()` under-requested by 8px per button and each pane rendered at 422px instead of the intended 430px. The width now lives once in `constants.module.scss` beside `$pane-divider-size`, so the two cannot drift apart again. The panes now land at exactly 430px.
- `restorePluginFromStore` re-asserts the preferred dimensions after the stores are restored. The existing MobX reaction only fires when the panel visibility flags actually change, so it misses the case where the restored flags match the defaults but the host clamped the startup request anyway.

`text-pane.test.tsx` pins which element is observed; I confirmed it fails against the pre-fix code. It is the repo's first component test, which is why jest needed an svg mock to get past the svgr imports.

### Testing notes

The bug only reproduces in the AP + CODAP V3 embedding, not in standalone CODAP, so this needs a check against the URLs in the Jira story once there is a preview build. Worth confirming both reported cases: clicking a single review should fill the tile, and highlighting two columns in the True vs. Predicted graph should give one review on each side.
