### PR TITLE
fix: Keep the window size when a pane is collapsed [STORYQ-77]

### DIFF
--- a/src/components/storyq.tsx
+++ b/src/components/storyq.tsx
@@ -1,4 +1,3 @@
-import { IReactionDisposer, reaction } from "mobx";
 import { observer } from "mobx-react";
 import React, { Component } from 'react';
 import { initializePlugin, registerObservers, updatePluginDimensions } from '../lib/codap-helper';
@@ -43,7 +42,6 @@ const Storyq = observer(class Storyq extends Component<IStoryqProps, {}> {
       height: pluginHeight
     };
     private testingManager: TestingManager;
-    private resizeDisposer: IReactionDisposer;
 
     constructor(props: IStoryqProps) {
       super(props);
@@ -65,14 +63,9 @@ const Storyq = observer(class Storyq extends Component<IStoryqProps, {}> {
       initializePlugin(this.kPluginName, this.kVersion, this.kInitialDimensions, this.restorePluginFromStore)
         .then(registerObservers).catch(registerObservers);
 
-      this.resizeDisposer = reaction(
-        () => [uiStore.showStoryQPanel, uiStore.showTextPanel],
-        () => updatePluginDimensions(getPluginWidth(), pluginHeight)
-      );
-    }
-
-    componentWillUnmount() {
-      this.resizeDisposer?.();
+      // Collapsing or expanding a pane deliberately leaves the window size alone. The panes are
+      // flex children, so the remaining one fills the space, and whatever width the user has set
+      // is preserved.
     }
 
     getPluginStore() {


### PR DESCRIPTION
Collapsing or expanding a pane resized the plugin window, throwing away any size the user had set. This removes the mobx reaction that did it, along with the now unused `resizeDisposer` and its `componentWillUnmount` teardown. Nothing replaces it.

No layout work was needed. The panes are flex children, so the remaining one already fills the space when the other is hidden.

### Why this shape

Jie was originally asked whether collapsing should narrow the window by the pane's width, keeping any extra size, or leave the window alone and let the remaining pane grow. She first chose the former, then revised after seeing that it silently discarded a resize made while collapsed:

> Oh, good point. I do want the plugin to remember the overall window size.

So StoryQ stops changing the window size once the window exists. A new plugin still opens at 908x420 from `kInitialDimensions`, which she confirmed, and which is safe because `CodapInterface.init` applies those dimensions only when there is no saved state.

### Verification

Local build loaded into `codap.concord.org/app` via `?di=http://localhost:3000`:

| Action | Tile size | |
|---|---|---|
| new instance | 908x420 | initial dimensions still apply |
| collapse a pane | 908x420 | unchanged; was 454 before |
| expand again | 908x420 | unchanged |
| user drags to 1158x540 | 1158x540 | respected |
| collapse at that size | 1158x540 | user's size kept |
| expand at that size | 1158x540 | user's size kept |
| both panes at 1108 wide | 530 / 532 | even split, no gap or overflow |

Height is never touched now either.

### Scope

**This does not fix STORYQ-79.** A document saved at 1158x540 still reopens at 908x420, because `restorePluginFromStore` re-asserts dimensions on the restore path. That is a one-line deletion once this lands, and it is deliberately kept separate so each PR maps to one ticket. PR 2 follows on top of this branch.
