### PR TITLE
fix: Keep a resized plugin window resized when reopened [STORYQ-79]

### DIFF
--- a/src/components/storyq.tsx
+++ b/src/components/storyq.tsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react";
 import React, { Component } from 'react';
-import { initializePlugin, registerObservers, updatePluginDimensions } from '../lib/codap-helper';
+import { initializePlugin, registerObservers } from '../lib/codap-helper';
 import codapInterface, { CODAP_Notification } from "../lib/CodapInterface";
 import { NotificationManager } from "../managers/notification_manager";
 import { TestingManager } from "../managers/testing_manager";
@@ -93,9 +93,8 @@ const Storyq = observer(class Storyq extends Component<IStoryqProps, {}> {
         uiStore.fromJSON(iStorage.uiStore);
         domainStore.fromJSON(iStorage.domainStore);
         await targetStore.updateFromCODAP()
-        // The restored panel visibility flags may not match the dimensions requested at startup,
-        // so re-assert the width we want now that they have settled.
-        updatePluginDimensions(getPluginWidth(), pluginHeight)
+        // The window size is deliberately left alone here. CODAP has already restored the size
+        // saved with the document, and that is the size the user chose.
       }
     }
 

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -359,13 +359,3 @@ export async function scrollCaseTableToRight(iDataContextName: string): Promise<
   }
   return false;
 }
-
-export async function updatePluginDimensions(width: number, height: number) {
-  codapInterface.sendRequest({
-    action: 'update',
-    resource: 'interactiveFrame',
-    values: {
-      dimensions: { width, height }
-    }
-  });
-}


### PR DESCRIPTION
> **Stacked on #72.** Base is `STORYQ-77-keep-window-size-on-collapse`, so review that one first. This diff is only the two files below.

Restoring a document re-asserted the plugin dimensions, overwriting the size CODAP had just restored from the saved document. A window saved at 1158x540 reopened at 908x420, losing the height as well as the width.

Removing that call lets CODAP's restored size stand.

### Why the helper goes too

With the pane-toggle reaction already removed in #72, this was the last place StoryQ resized an existing window, leaving `updatePluginDimensions` with no callers. It is exported, so lint will not flag it, and a ready-made "resize the plugin window" helper is exactly the footgun these two stories exist to close.

### Why this is safe for new plugins

A brand new instance still opens at 908x420. `CodapInterface.init` applies `kInitialDimensions` only when there is no saved state:

```js
if (!savedState) {
  // this is a new instance of the plugin so use the initial dimensions passed - existing instances
  // will have their saved dimensions set by CODAP when the plugin is added to the document
  const values = {dimensions: iConfig.dimensions};
  await codapInterface.sendRequest({ action: "update", resource: "interactiveFrame", values});
}
```

### Verification

Local build loaded into `codap.concord.org/app` via `?di=http://localhost:3000`, using a shared document deliberately saved with the plugin at 1158x540:

| Action | Tile size | |
|---|---|---|
| reopen the 1158x540 document | **1158x540** | was 908x420 before this change |
| collapse a pane in it | 1158x540 | #72 not regressed |
| expand again | 1158x540 | |
| brand new instance | 908x420 | initial dimensions still apply |

### Together with #72

The two PRs establish one rule: **CODAP owns the plugin window size; StoryQ sets it only when creating a new plugin.** After both, there is no code path that resizes an existing window.
